### PR TITLE
CI infra: AI-free core CLI for the payment image + resilient coverage comment

### DIFF
--- a/.github/workflows/payment-tests.yml
+++ b/.github/workflows/payment-tests.yml
@@ -95,6 +95,9 @@ jobs:
 
       - name: Comment coverage on PR
         if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
+        # A coverage PR comment is informational and fails for forks / missing
+        # permissions; it must never fail the test job.
+        continue-on-error: true
         uses: py-cov-action/python-coverage-comment-action@v3
         with:
           GITHUB_TOKEN: ${{ github.token }}

--- a/Dockerfile.payment
+++ b/Dockerfile.payment
@@ -55,6 +55,12 @@ RUN /root/.local/bin/uv pip install --system \
     'rapidfuzz>=3.0.0' \
     # Configuration
     'python-dotenv>=1.0.0' \
+    'platformdirs>=4.0.0' \
+    # Internationalization (the CLI renders all text via Fluent/Babel)
+    'fluent-runtime>=0.4.0' \
+    'babel>=2.14.0' \
+    # OFX/QFX parsing pulls in BeautifulSoup
+    'beautifulsoup4>=4.12.0' \
     # Logging
     'structlog>=24.1.0' \
     # PDF Generation

--- a/openfatture/cli/lifespan.py
+++ b/openfatture/cli/lifespan.py
@@ -5,28 +5,26 @@ Provides graceful startup and shutdown handling for async resources,
 preventing event loop race conditions during application termination.
 """
 
+from __future__ import annotations
+
 import asyncio
 import signal
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from contextvars import ContextVar
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import httpx
 
-from openfatture.ai.ml.retraining import (
-    RetrainingScheduler,
-)
-from openfatture.ai.ml.retraining import (
-    get_scheduler as get_retraining_scheduler,
-)
-from openfatture.ai.rag.auto_update import (
-    AutoIndexingService,
-    get_auto_indexing_service,
-    get_auto_update_config,
-    setup_event_listeners,
-    teardown_event_listeners,
-)
+# The AI/ML self-learning stack (retraining scheduler, RAG auto-update) is heavy
+# and optional. Import it lazily inside the methods that use it so the core CLI
+# (and a minimal, AI-free install such as the payment-only Docker image) can
+# start without the AI extras; only type names are imported eagerly, guarded by
+# TYPE_CHECKING.
+if TYPE_CHECKING:
+    from openfatture.ai.ml.retraining import RetrainingScheduler
+    from openfatture.ai.rag.auto_update import AutoIndexingService
+
 from openfatture.core.events import GlobalEventBus, initialize_event_system
 from openfatture.core.hooks import HookEventBridge, initialize_hook_system
 from openfatture.utils.async_bridge import run_async
@@ -105,6 +103,15 @@ class LifespanManager:
     async def _initialize_self_learning(self) -> None:
         """Initialize self-learning systems."""
         try:
+            from openfatture.ai.ml.retraining import (
+                get_scheduler as get_retraining_scheduler,
+            )
+            from openfatture.ai.rag.auto_update import (
+                get_auto_indexing_service,
+                get_auto_update_config,
+                setup_event_listeners,
+            )
+
             # Setup RAG auto-update event listeners
             logger.debug("Setting up RAG auto-update event listeners")
             setup_event_listeners()
@@ -192,6 +199,8 @@ class LifespanManager:
     async def _shutdown_self_learning(self) -> None:
         """Shutdown self-learning systems gracefully."""
         try:
+            from openfatture.ai.rag.auto_update import teardown_event_listeners
+
             # Stop retraining scheduler
             if self.retraining_scheduler:
                 logger.debug("Stopping retraining scheduler")

--- a/openfatture/cli/main.py
+++ b/openfatture/cli/main.py
@@ -1,18 +1,21 @@
 """Main CLI entry point for OpenFatture."""
 
+from importlib import import_module
+
 import typer
 from rich.console import Console
 
 from openfatture import __version__
 from openfatture.utils.config import get_settings
-from openfatture.utils.logging import configure_dynamic_logging
+from openfatture.utils.logging import configure_dynamic_logging, get_logger
+
+logger = get_logger(__name__)
 
 # Payment CLI lives in the payment package to keep the top-level commands lean.
 from ..payment.cli import app as payment_app
 
-# Import command modules
+# Import core command modules (lightweight, always available).
 from .commands import (
-    ai,
     batch,
     cliente,
     config,
@@ -22,14 +25,22 @@ from .commands import (
     hooks,
     init,
     interactive,
-    lightning,
-    media,
     notifiche,
     pec,
     plugin,
     preventivo,
     report,
-    web_scraper,
+)
+
+# Optional command groups that pull in heavy/optional dependencies (AI/ML stack,
+# browser automation, gRPC). They are imported defensively below so a minimal
+# install — e.g. the payment-only Docker image without the AI/ML extras — still
+# exposes the core commands; a missing dependency disables only its own group.
+_OPTIONAL_GROUPS: tuple[tuple[str, str, str], ...] = (
+    ("ai", "ai", "AI-powered assistance"),
+    ("lightning", "lightning", "Lightning Network payments"),
+    ("media", "media", "Media automation & VHS generation"),
+    ("web_scraper", "web-scraper", "Regulatory web scraping"),
 )
 
 # Create main app and console
@@ -193,15 +204,20 @@ app.add_typer(pec.app, name="pec", help="PEC configuration and testing")
 app.add_typer(email.app, name="email", help="Email templates & testing")
 app.add_typer(notifiche.app, name="notifiche", help="SDI notifications")
 app.add_typer(batch.app, name="batch", help="Batch operations")
-app.add_typer(ai.app, name="ai", help="AI-powered assistance")
-app.add_typer(lightning.app, name="lightning", help="Lightning Network payments")
-app.add_typer(media.app, name="media", help="Media automation & VHS generation")
 app.add_typer(hooks.app, name="hooks", help="Manage lifecycle hooks")
 app.add_typer(events.app, name="events", help="View event history & audit log")
 app.add_typer(report.app, name="report", help="Generate reports")
-app.add_typer(web_scraper.app, name="web-scraper", help="Regulatory web scraping")
 app.add_typer(plugin.app, name="plugin", help="Manage plugins")
 app.add_typer(payment_app, name="payment", help="Payment tracking & reconciliation")
+
+# Register optional command groups, skipping any whose dependencies are absent.
+for _module_name, _command_name, _help_text in _OPTIONAL_GROUPS:
+    try:
+        _group = import_module(f"{__package__}.commands.{_module_name}")
+    except ModuleNotFoundError as exc:  # optional extra not installed
+        logger.debug("optional_command_group_unavailable", group=_command_name, error=str(exc))
+        continue
+    app.add_typer(_group.app, name=_command_name, help=_help_text)
 
 # Pre-load plugins and register their CLI commands
 try:


### PR DESCRIPTION
Fixes the two pre-existing CI-infra failures left red on `main` (they were never regressions from the testing overhaul, but worth fixing).

## Docker payment image (`ModuleNotFoundError`)
The payment-only Docker image (`Dockerfile.payment`, deliberately AI/ML-free) ran `python -m openfatture.cli.main payment --help`, but `cli/main.py` imported **every** command group at module top and `cli/lifespan.py` imported the AI/ML self-learning stack eagerly — so the whole CLI pulled in `chromadb`/`prophet`/`xgboost`/`openai`/`anthropic`. `platformdirs` was merely the first missing module.

- `cli/main.py`: register the heavy command groups (`ai`, `lightning`, `media`, `web-scraper`) defensively — a missing optional extra disables only its group.
- `cli/lifespan.py`: import the retraining/RAG-auto-update stack lazily inside the methods that use it (TYPE_CHECKING for annotations).
- Verified by simulation: with the AI/ML stack absent, `cli.main` still loads and the **core + payment** commands work; the full install is unchanged (all 19 groups present, CLI smoke green).
- `Dockerfile.payment`: add the core runtime deps the CLI needs regardless of AI — `platformdirs`, `fluent-runtime`, `babel`, `beautifulsoup4`.

## Payment coverage job (3.13)
The `Test Payment Module` job failed on its `Comment coverage on PR` step (the `python-coverage-comment-action` fails on forks / missing permissions). A coverage comment is informational and must never fail the job → `continue-on-error: true`. (The macOS-3.13 leg's other red was a transient PyPI network error fetching a wheel, not a code issue.)

## Validation
- Default gate unchanged: **2004 passed, 0 failed**.
- `openfatture --help`, `payment --help`, `ai --help` all OK in a full install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)