### PR TITLE
chore(gitignore): stop shadowing the ml models package and untrack a local lock

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"3c0b042b-7a51-47ca-b530-10f11ccaba35","pid":3697192,"procStart":"31802507","acquiredAt":1780245970129}

--- a/.gitignore
+++ b/.gitignore
@@ -65,14 +65,19 @@ dmypy.json
 *.log
 
 # OpenFatture Specific
-data/
-archivio/
-certificates/
+# Anchored to the repo root: these are runtime directories (they default to the
+# platformdirs user paths), not names that should be ignored at any depth.
+/data/
+/archivio/
+/certificates/
 *.p7m
 *.xml.p7m
 
 # AI Models Cache
-models/
+# OPENFATTURE_ML_MODEL_PATH defaults to .models/. An unanchored `models/` here
+# also shadowed the openfatture/ai/ml/models/ source package, silently ignoring
+# any new module added to it.
+/.models/
 .cache/
 
 # ChromaDB Vector Store
@@ -106,3 +111,9 @@ openfatture-plugin-*/
 # Landing Page
 landing-page/node_modules/
 landing-page/dist/
+
+# Claude Code machine-local state
+# Shared project config under .claude/ stays tracked; these two are per-machine
+# (the lock file records a PID and session id).
+.claude/scheduled_tasks.lock
+.claude/settings.local.json


### PR DESCRIPTION
## Cosa

Due correzioni a `.gitignore`, più la rimozione dal tracking di un file di stato locale.

### `models/` oscurava un package sorgente

La regola non era ancorata, quindi corrispondeva a qualsiasi profondità e copriva `openfatture/ai/ml/models/`:

```
$ git check-ignore -v openfatture/ai/ml/models/new_model.py
.gitignore:75:models/	openfatture/ai/ml/models/new_model.py
```

I quattro moduli già presenti sono tracciati e quindi non impattati, ma **qualsiasi nuovo modello aggiunto lì sarebbe stato ignorato in silenzio**. La regola puntava anche al path sbagliato: la cache dei modelli è `.models/` (`OPENFATTURE_ML_MODEL_PATH`), non `models/`.

### Directory runtime non ancorate

`data/`, `archivio/` e `certificates/` hanno come default i path utente di platformdirs: qui sono nomi a livello di root, non nomi da ignorare ovunque compaiano. Ancorate per evitare la stessa classe di problema.

### `.claude/scheduled_tasks.lock`

Committato per errore in `1e48b8c`. È stato locale della macchina, contiene un PID e un session id:

```json
{"sessionId":"3c0b042b-...","pid":3697192,"procStart":"31802507","acquiredAt":1780245970129}
```

Rimosso dal tracking e ignorato, insieme a `settings.local.json`. La config di progetto condivisa sotto `.claude/` resta tracciata.

## Verifica

Nessuna directory sorgente tracciata risulta più ignorata, i target reali restano coperti, e la config condivisa resta tracciabile:

| path | esito |
|---|---|
| `.models/prophet.pkl` | ignorato |
| `data/db.sqlite`, `archivio/2025/f.xml`, `certificates/cert.p12` | ignorati |
| `.claude/scheduled_tasks.lock`, `.claude/settings.local.json` | ignorati |
| `.claude/settings.json`, `.claude/agents/foo.md` | tracciabili |
| `openfatture/ai/ml/models/new_model.py` | tracciabile |

🤖 Generated with [Claude Code](https://claude.com/claude-code)