### PR TITLE
fix(status): readiness next_steps when AI credentials missing (v2.0.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.2] - 2026-08-07
+
+### Fixed
+
+- Status readiness no longer suggests enabling the AI extra when the extra is
+  already installed and only credentials are missing.
+
 ## [2.0.1] - 2026-08-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ See [docs/CLI_REFERENCE.md](docs/CLI_REFERENCE.md).
 
 ## Status
 
-Version **2.0.1**, Python 3.12+ and `uv`. Packaging, extras, honesty gates, and
+Version **2.0.2**, Python 3.12+ and `uv`. Packaging, extras, honesty gates, and
 the unified assistant runtime shipped in 2.0 — see
-[docs/STATUS.md](docs/STATUS.md), [docs/releases/v2.0.1.md](docs/releases/v2.0.1.md),
+[docs/STATUS.md](docs/STATUS.md), [docs/releases/v2.0.2.md](docs/releases/v2.0.1.md),
 and [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
 Explicit non-goal: there is no browser frontend or web application surface,

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ This is the current documentation index for the CLI-first, agentic product.
 - [CLI reference](CLI_REFERENCE.md)
 - [Configuration](CONFIGURATION.md)
 - [Project status](STATUS.md)
+- [Release notes v2.0.2](releases/v2.0.2.md)
 - [Release notes v2.0.1](releases/v2.0.1.md)
 - [Release notes v2.0.0](releases/v2.0.0.md)
 - [Architecture](ARCHITECTURE.md)

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # OpenFatture project status
 
-**Current version:** 2.0.1  
+**Current version:** 2.0.2  
 **Product posture:** CLI-first, with an interactive terminal mode for guided workflows  
 **Runtime:** Python 3.12+ and `uv`
 
@@ -45,8 +45,8 @@ fix the root cause instead.
    `ai.tools.registry` is already a package)
 4. Onboarding polish continues (readiness in `status`, slash commands in assistant)
 
-See [TECHNICAL_DEBT.md](TECHNICAL_DEBT.md), [releases/v2.0.1.md](releases/v2.0.1.md),
-and [releases/v2.0.0.md](releases/v2.0.0.md).
+See [TECHNICAL_DEBT.md](TECHNICAL_DEBT.md), [releases/v2.0.2.md](releases/v2.0.2.md),
+and [releases/v2.0.1.md](releases/v2.0.1.md).
 
 ## Explicit non-goals
 

--- a/docs/releases/v2.0.2.md
+++ b/docs/releases/v2.0.2.md
@@ -1,0 +1,14 @@
+# OpenFatture v2.0.2
+
+**Release date:** 7 August 2026  
+**Status:** Patch on 2.0.1
+
+## Fixed
+
+- `status` readiness `next_steps`: when the `ai` extra is installed but
+  credentials are missing, guidance points to `AI_API_KEY` / Ollama — not a
+  false “enable the ai extra” message.
+
+## See also
+
+- [v2.0.1](v2.0.1.md)

--- a/openfatture/__init__.py
+++ b/openfatture/__init__.py
@@ -5,6 +5,6 @@ A modern, CLI-first invoicing system with AI-powered workflows and full
 compliance with FatturaPA and SDI requirements.
 """
 
-__version__ = "2.0.1"
+__version__ = "2.0.2"
 __author__ = "Venere Labs"
 __license__ = "MIT"

--- a/openfatture/cli/commands/status.py
+++ b/openfatture/cli/commands/status.py
@@ -47,7 +47,8 @@ def _readiness(settings: Settings, extras: dict[str, bool]) -> dict[str, Any]:
         next_steps.append("Set AI_API_KEY (or use AI_PROVIDER=ollama)")
     if core_ready and assistant_ready:
         next_steps.append('Try: openfatture assistant "Elenca le fatture aperte"')
-    elif core_ready and not assistant_ready:
+    elif core_ready and not ai_extra:
+        # Only when the ai extra itself is missing — not when credentials alone fail.
         next_steps.append("Core is ready; enable the ai extra to use the assistant")
     if not next_steps:
         next_steps.append("openfatture --help")

--- a/tests/cli/test_status_readiness.py
+++ b/tests/cli/test_status_readiness.py
@@ -1,0 +1,81 @@
+"""Unit tests for status readiness guidance (honest next_steps)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+from openfatture.cli.commands.status import _readiness
+from openfatture.platform.config import Settings
+
+
+def _settings(
+    *,
+    partita_iva: str = "12345678901",
+    denominazione: str = "Acme SRL",
+    data_dir: Path,
+    ai_provider: str = "openai",
+    ai_api_key: str = "",
+) -> Settings:
+    """Build a structural stand-in that exercises the shipped _readiness path."""
+    return cast(
+        Settings,
+        SimpleNamespace(
+            cedente_partita_iva=partita_iva,
+            cedente_denominazione=denominazione,
+            data_dir=data_dir,
+            archivio_dir=data_dir / "archivio",
+            ai_provider=ai_provider,
+            ai_api_key=ai_api_key,
+        ),
+    )
+
+
+def test_readiness_ai_extra_without_key_does_not_say_enable_extra(tmp_path: Path) -> None:
+    """When ai extra is installed but credentials missing, guide to key/ollama only."""
+    data = tmp_path / "data"
+    data.mkdir()
+    (data / "archivio").mkdir()
+    settings = _settings(data_dir=data, ai_provider="openai", ai_api_key="")
+    extras = {"ai": True, "rag": False, "ml": False, "lightning": False}
+
+    result = _readiness(settings, extras)
+
+    assert result["core_ready"] is True
+    assert result["assistant_ready"] is False
+    assert result["checks"]["ai_extra"] is True
+    assert result["checks"]["ai_credentials"] is False
+    steps = result["next_steps"]
+    assert any("AI_API_KEY" in s or "ollama" in s.lower() for s in steps)
+    assert not any("enable the ai extra" in s.lower() for s in steps)
+    assert not any("uv sync --extra ai" in s for s in steps)
+
+
+def test_readiness_missing_ai_extra_suggests_sync(tmp_path: Path) -> None:
+    data = tmp_path / "data"
+    data.mkdir()
+    (data / "archivio").mkdir()
+    settings = _settings(data_dir=data)
+    extras = {"ai": False, "rag": False, "ml": False, "lightning": False}
+
+    result = _readiness(settings, extras)
+
+    assert result["core_ready"] is True
+    assert result["assistant_ready"] is False
+    assert any("uv sync --extra ai" in s for s in result["next_steps"])
+    assert any("enable the ai extra" in s.lower() for s in result["next_steps"])
+
+
+def test_readiness_full_ready_suggests_assistant(tmp_path: Path) -> None:
+    data = tmp_path / "data"
+    data.mkdir()
+    (data / "archivio").mkdir()
+    settings = _settings(data_dir=data, ai_provider="openai", ai_api_key="sk-test")
+    extras = {"ai": True}
+
+    result = _readiness(settings, extras)
+
+    assert result["core_ready"] is True
+    assert result["assistant_ready"] is True
+    assert any("openfatture assistant" in s for s in result["next_steps"])


### PR DESCRIPTION
## Summary

Patch **2.0.2**: fix misleading status readiness guidance.

When the `ai` extra is installed but credentials are missing, `next_steps`
no longer says “enable the ai extra”. It only guides to `AI_API_KEY` / Ollama.

Adds unit tests for the shipped `_readiness()` helper covering:
- ai extra + no key → no false “enable ai extra”
- no ai extra → sync / enable guidance
- full ready → assistant try step

## Test plan

- [x] `pytest tests/cli/test_status_readiness.py tests/cli/test_public_surface.py`
- [x] ruff on touched files
- [ ] CI green