### PR TITLE
docs: fix README v2.0.2 release notes href

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ See [docs/CLI_REFERENCE.md](docs/CLI_REFERENCE.md).
 
 Version **2.0.2**, Python 3.12+ and `uv`. Packaging, extras, honesty gates, and
 the unified assistant runtime shipped in 2.0 — see
-[docs/STATUS.md](docs/STATUS.md), [docs/releases/v2.0.2.md](docs/releases/v2.0.1.md),
+[docs/STATUS.md](docs/STATUS.md), [docs/releases/v2.0.2.md](docs/releases/v2.0.2.md),
 and [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
 Explicit non-goal: there is no browser frontend or web application surface,


### PR DESCRIPTION
## Summary

Fix README status section: link label and href both target `docs/releases/v2.0.2.md`.

## Test plan

- [x] Structural audit: release markdown links have matching label/href and existing targets
- [ ] CI green