### PR TITLE
feat(ai): opt-in LangGraph product assistant backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Opt-in LangGraph product assistant backend (`ASSISTANT_BACKEND=langgraph` /
+  `assistant_backend` setting). Default remains `chat`.
+- Shared chat prompt helpers (`ai.runtime.prompt`) used by both backends.
+- `GraphAssistantBackend` with `run` + node-granularity `stream` (`StreamEvent`).
+- Status fields `assistant_backend` and `assistant_backend_id`.
+- Parity tests: chat vs langgraph tool round-trips, max iterations, streaming
+  event order, session message sequence.
+
+### Changed
+
+- `AssistantRuntime` resolves backend from settings/ctor; populates
+  `context.available_tools` so native tool loops actually engage.
+- `build_assistant_graph` no longer re-enters `runtime.run` (no circular facade).
+
 ## [2.0.2] - 2026-08-07
 
 ### Fixed

--- a/docs/AI_ARCHITECTURE.md
+++ b/docs/AI_ARCHITECTURE.md
@@ -11,10 +11,16 @@ CLI assistant / interactive
         v
 openfatture.ai.runtime.AssistantRuntime
         │
-        v
-ChatAgent tool loop          ← product backend (status: chat_agent_tool_loop)
-  ├── NativeToolOrchestrator  (providers with native tools)
-  └── ReActOrchestrator       (fallback)
+        ├── assistant_backend=chat (default)
+        │     ChatAgent tool loop (status id: chat_agent_tool_loop)
+        │       ├── NativeToolOrchestrator  (providers with native tools)
+        │       └── ReActOrchestrator       (fallback / Ollama)
+        │
+        └── assistant_backend=langgraph (opt-in)
+              GraphAssistantBackend (status id: langgraph_tool_loop)
+                ├── StateGraph call_model ↔ call_tools
+                ├── ReAct node when provider lacks native tools
+                └── node-granularity StreamEvent streaming
         │
         v
 ToolRegistry → application services (billing.*) → storage
@@ -24,8 +30,11 @@ ToolRegistry → application services (billing.*) → storage
 # Preferred API for embedders / tests
 from openfatture.ai.runtime import create_assistant_runtime, run_assistant
 
-runtime = create_assistant_runtime()
+runtime = create_assistant_runtime()  # default: chat
 response = await runtime.run("Elenca le fatture non pagate")
+
+# Opt-in LangGraph product backend (or set ASSISTANT_BACKEND=langgraph)
+runtime = create_assistant_runtime(backend="langgraph")
 ```
 
 Interactive sessions can persist to the file session store
@@ -34,19 +43,22 @@ Interactive sessions can persist to the file session store
 loaded from the store (do not also pass a parallel in-memory history that
 duplicates turns).
 
-## Optional LangGraph multi-node helper (not the product path)
+## LangGraph product backend (opt-in)
 
-`build_tool_loop_graph` / `build_assistant_graph` compile a model↔tools
-StateGraph for tests, observability, or a future product switch. **2.0.0 does
-not route CLI traffic through this graph** (policy B1-β). Promoting it to the
-product path requires explicit parity tests.
+`GraphAssistantBackend` is a first-class product path behind the same facade.
+Default remains **`chat`** until a later release flips the default after soak.
+Parity tests (`tests/ai/test_assistant_backend_parity.py`) gate readiness.
 
 ```python
 from openfatture.ai.runtime.graph import build_assistant_graph
 
-graph = build_assistant_graph(runtime)
+graph = build_assistant_graph(runtime)  # helper / tests; CLI uses runtime.backend
 await graph.ainvoke({"user_input": "..."})
 ```
+
+Set `ASSISTANT_BACKEND=langgraph` or `assistant_backend = "langgraph"` in
+config. Check with `openfatture status --json` (`assistant_backend`,
+`assistant_backend_id`).
 
 ## Boundaries
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -59,6 +59,7 @@ uv sync --all-extras
 | `AI_MODEL` | Provider model name |
 | `AI_API_KEY` | Provider credential |
 | `AI_BASE_URL` | Local provider endpoint, such as Ollama |
+| `ASSISTANT_BACKEND` | Product assistant orchestration: `chat` (default) or `langgraph` (opt-in StateGraph tool loop) |
 
 Sensitive values should be provided through the environment or a protected
 local secrets file. Do not commit credentials.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -38,8 +38,9 @@ fix the root cause instead.
 
 ## Current focus (post-2.0)
 
-1. LangGraph remains a tested helper (B1-β); parity tests cover tool-loop shape —
-   flip only with feature flag + full streaming parity
+1. **LangGraph product backend is opt-in** (`ASSISTANT_BACKEND=langgraph`);
+   default remains `chat` / `chat_agent_tool_loop`. Parity + stream tests gate
+   any future default flip. Multi-agent workflows stay non-CLI.
 2. Lightning real LND gRPC **or** keep hard experimental posture
 3. Continue splitting oversized modules (`cash_flow_predictor`, ops facades;
    `ai.tools.registry` is already a package)

--- a/openfatture/ai/agents/chat_agent.py
+++ b/openfatture/ai/agents/chat_agent.py
@@ -4,7 +4,7 @@ import json
 from collections.abc import AsyncIterator
 from typing import Any
 
-from openfatture.ai.domain import AgentConfig, BaseAgent, Message, Role
+from openfatture.ai.domain import AgentConfig, BaseAgent, Message
 from openfatture.ai.domain.context import ChatContext
 from openfatture.ai.domain.response import AgentResponse, ResponseStatus
 from openfatture.ai.orchestration.native_tools import NativeToolOrchestrator
@@ -114,6 +114,11 @@ class ChatAgent(BaseAgent[ChatContext]):
 
         return True, None
 
+    def _ensure_available_tools(self, context: ChatContext) -> None:
+        """Populate tool names on context when tools are enabled and list is empty."""
+        if self.enable_tools and not context.available_tools:
+            context.available_tools = self.get_available_tools()
+
     async def execute(self, context: ChatContext, **kwargs: Any) -> AgentResponse:
         """Execute chat agent, dispatching to native tool calling or ReAct.
 
@@ -128,6 +133,7 @@ class ChatAgent(BaseAgent[ChatContext]):
         native tools, a forced structured-output call is performed instead.
         """
         collector = get_metrics_collector()
+        self._ensure_available_tools(context)
 
         with MetricsTimer("chat_agent_execute", {"agent": self.config.name}):
             try:
@@ -354,6 +360,7 @@ class ChatAgent(BaseAgent[ChatContext]):
         Yields:
             StreamEvent: Typed streaming events (CONTENT, TOOL_START, TOOL_RESULT, etc.)
         """
+        self._ensure_available_tools(context)
         # Check if we need ReAct orchestration
         needs_react = (
             self.enable_tools
@@ -634,125 +641,16 @@ class ChatAgent(BaseAgent[ChatContext]):
             yield StreamEvent.content(f"\n\nErrore durante l'esecuzione: {str(e)}")
 
     async def _build_prompt(self, context: ChatContext) -> list[Message]:
-        """
-        Build prompt messages for chat.
+        """Build prompt messages (shared helper with LangGraph product backend)."""
+        from openfatture.ai.runtime.prompt import build_chat_messages
 
-        Constructs a conversation with:
-        - System prompt with context
-        - Conversation history
-        - Current user message
-
-        Args:
-            context: Chat context
-
-        Returns:
-            List of messages for LLM
-        """
-        messages = []
-
-        # System prompt with context enrichment
-        system_prompt = self._build_system_prompt(context)
-        messages.append(Message(role=Role.SYSTEM, content=system_prompt))
-
-        # Add conversation history
-        for msg in context.conversation_history.get_messages(include_system=False):
-            messages.append(msg)
-
-        # Add current user message if not already in history
-        if not messages or messages[-1].role != Role.USER:
-            messages.append(Message(role=Role.USER, content=context.user_input))
-
-        logger.debug(
-            "prompt_built",
-            agent=self.config.name,
-            total_messages=len(messages),
-            history_messages=len(context.conversation_history.messages),
-        )
-
-        return messages
+        return build_chat_messages(context, enable_tools=self.enable_tools)
 
     def _build_system_prompt(self, context: ChatContext) -> str:
-        """
-        Build system prompt with context enrichment.
+        """Build system prompt (shared helper with LangGraph product backend)."""
+        from openfatture.ai.runtime.prompt import build_chat_system_prompt
 
-        Args:
-            context: Chat context
-
-        Returns:
-            System prompt string
-        """
-        parts = [
-            "Sei un assistente AI specializzato per OpenFatture, un sistema di fatturazione elettronica italiana.",
-            "",
-            "Il tuo ruolo è:",
-            "- Rispondere a domande su fatture e clienti",
-            "- Fornire statistiche e insights",
-            "- Guidare l'utente attraverso i workflow",
-            "- Eseguire azioni tramite tools quando necessario",
-            "",
-            "Regole:",
-            "- Usa un tono professionale ma friendly",
-            "- Rispondi in italiano (salvo richiesta diversa)",
-            "- Se non hai informazioni sufficienti, chiedi chiarimenti",
-            "- Prima di eseguire azioni distruttive, chiedi conferma",
-            "- Cita i dati specifici quando disponibili (numeri, date, importi)",
-        ]
-
-        # Add business context if available
-        if context.current_year_stats:
-            stats = context.current_year_stats
-            parts.extend(
-                [
-                    "",
-                    "Contesto corrente:",
-                    f"- Anno: {stats.get('anno', 'N/A')}",
-                    f"- Fatture totali: {stats.get('totale_fatture', 0)}",
-                    f"- Importo totale: €{stats.get('importo_totale', 0):.2f}",
-                ]
-            )
-
-        # Add available tools info
-        if self.enable_tools and context.available_tools:
-            parts.extend(
-                [
-                    "",
-                    "Strumenti disponibili:",
-                    f"- Hai accesso a {len(context.available_tools)} tools",
-                    "- Usa i tools per recuperare dati o eseguire azioni",
-                    "- I tools includono: ricerca fatture, statistiche, info clienti",
-                ]
-            )
-
-        if context.relevant_documents:
-            parts.extend(
-                [
-                    "",
-                    "Documenti rilevanti dal sistema (fatture correlate):",
-                ]
-            )
-            for doc in context.relevant_documents[:5]:
-                parts.append(f"- {doc}")
-
-        if context.knowledge_snippets:
-            parts.extend(
-                [
-                    "",
-                    "Fonti normative e note operative da consultare (cita come [numero]):",
-                ]
-            )
-            for idx, snippet in enumerate(context.knowledge_snippets[:5], 1):
-                citation = snippet.get("citation") or snippet.get("source") or f"Fonte {idx}"
-                excerpt = snippet.get("excerpt", "")
-                parts.append(f"[{idx}] {citation} — {excerpt}")
-
-            parts.extend(
-                [
-                    "",
-                    "Usa le fonti sopra per supportare la risposta e indica il riferimento con [numero].",
-                ]
-            )
-
-        return "\n".join(parts)
+        return build_chat_system_prompt(context, enable_tools=self.enable_tools)
 
     async def _parse_response(
         self,

--- a/openfatture/ai/runtime/__init__.py
+++ b/openfatture/ai/runtime/__init__.py
@@ -3,18 +3,49 @@
 All user-facing assistant flows MUST go through this package. Multi-agent
 LangGraph workflows under ``ai.orchestration.workflows`` are internal/experimental
 and are not registered on the public CLI.
+
+Import ``constants`` for backend ids without constructing a runtime.
 """
 
-from openfatture.ai.runtime.service import (
-    AssistantRuntime,
-    create_assistant_runtime,
-    run_assistant,
-    stream_assistant,
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from openfatture.ai.runtime.constants import (
+    ASSISTANT_BACKEND_CHAT,
+    ASSISTANT_BACKEND_LANGGRAPH,
+    BACKEND_CHAT,
+    BACKEND_LANGGRAPH,
+    AssistantBackendName,
+    resolve_backend_id,
 )
 
+if TYPE_CHECKING:
+    from openfatture.ai.runtime.service import AssistantRuntime
+
 __all__ = [
+    "ASSISTANT_BACKEND_CHAT",
+    "ASSISTANT_BACKEND_LANGGRAPH",
+    "BACKEND_CHAT",
+    "BACKEND_LANGGRAPH",
+    "AssistantBackendName",
     "AssistantRuntime",
     "create_assistant_runtime",
+    "resolve_backend_id",
     "run_assistant",
     "stream_assistant",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazy-load heavy runtime symbols so ``constants`` imports stay light."""
+    if name in {
+        "AssistantRuntime",
+        "create_assistant_runtime",
+        "run_assistant",
+        "stream_assistant",
+    }:
+        from openfatture.ai.runtime import service as _service
+
+        return getattr(_service, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/openfatture/ai/runtime/constants.py
+++ b/openfatture/ai/runtime/constants.py
@@ -1,0 +1,33 @@
+"""Stable identifiers and shared constants for the assistant runtime."""
+
+from __future__ import annotations
+
+from typing import Final, Literal
+
+# Product backend ids (status/metrics; stable contract)
+BACKEND_CHAT: Final = "chat_agent_tool_loop"
+BACKEND_LANGGRAPH: Final = "langgraph_tool_loop"
+
+# Settings values map to backend ids (Literal keeps mypy/runtime aligned)
+AssistantBackendName = Literal["chat", "langgraph"]
+ASSISTANT_BACKEND_CHAT: Final[Literal["chat"]] = "chat"
+ASSISTANT_BACKEND_LANGGRAPH: Final[Literal["langgraph"]] = "langgraph"
+
+DEFAULT_TOOL_MAX_ITERATIONS: Final[int] = 5
+
+BACKEND_IDS: Final[dict[str, str]] = {
+    ASSISTANT_BACKEND_CHAT: BACKEND_CHAT,
+    ASSISTANT_BACKEND_LANGGRAPH: BACKEND_LANGGRAPH,
+}
+
+
+def resolve_backend_id(assistant_backend: str) -> str:
+    """Map settings ``assistant_backend`` to the stable backend id string."""
+    key = (assistant_backend or ASSISTANT_BACKEND_CHAT).strip().lower()
+    if key == ASSISTANT_BACKEND_LANGGRAPH:
+        return BACKEND_LANGGRAPH
+    if key == ASSISTANT_BACKEND_CHAT:
+        return BACKEND_CHAT
+    raise ValueError(
+        f"Unknown assistant_backend={assistant_backend!r}; expected one of {sorted(BACKEND_IDS)}"
+    )

--- a/openfatture/ai/runtime/graph.py
+++ b/openfatture/ai/runtime/graph.py
@@ -13,12 +13,22 @@ Experimental multi-agent workflows remain under ``ai.orchestration.workflows``.
 from __future__ import annotations
 
 import json
-from typing import Any, Literal, TypedDict
+from typing import Any, Literal, Protocol, TypedDict
 
+from openfatture.ai.domain.message import Message, Role
+from openfatture.ai.providers.base import BaseLLMProvider
+from openfatture.ai.tools.registry import ToolRegistry
 from openfatture.platform.extras import require_extra
 from openfatture.platform.logging import get_logger
 
 logger = get_logger(__name__)
+
+
+class _RuntimeProviderAccess(Protocol):
+    """Minimal surface of AssistantRuntime needed to build a graph."""
+
+    _provider: BaseLLMProvider
+    _tool_registry: ToolRegistry
 
 
 class ToolLoopState(TypedDict, total=False):
@@ -36,32 +46,25 @@ class ToolLoopState(TypedDict, total=False):
     tool_results: list[dict[str, Any]]
 
 
-def _message_to_dict(msg: Any) -> dict[str, Any]:
-    from openfatture.ai.domain.message import Message
-
+def _message_to_dict(msg: Message | dict[str, Any]) -> dict[str, Any]:
     if isinstance(msg, dict):
         return msg
-    if isinstance(msg, Message):
-        data: dict[str, Any] = {
-            "role": msg.role.value if hasattr(msg.role, "value") else str(msg.role),
-            "content": msg.content or "",
-        }
-        if msg.tool_calls:
-            data["tool_calls"] = msg.tool_calls
-        if msg.tool_call_id:
-            data["tool_call_id"] = msg.tool_call_id
-        if msg.name:
-            data["name"] = msg.name
-        return data
-    raise TypeError(f"Unsupported message type: {type(msg)}")
+    data: dict[str, Any] = {
+        "role": msg.role.value,
+        "content": msg.content or "",
+    }
+    if msg.tool_calls:
+        data["tool_calls"] = msg.tool_calls
+    if msg.tool_call_id:
+        data["tool_call_id"] = msg.tool_call_id
+    if msg.name:
+        data["name"] = msg.name
+    return data
 
 
-def _dict_to_message(data: dict[str, Any]) -> Any:
-    from openfatture.ai.domain.message import Message, Role
-
-    role = data.get("role", "user")
-    if isinstance(role, str):
-        role = Role(role)
+def _dict_to_message(data: dict[str, Any]) -> Message:
+    role_raw = data.get("role", "user")
+    role = Role(role_raw) if isinstance(role_raw, str) else role_raw
     return Message(
         role=role,
         content=data.get("content") or "",
@@ -73,8 +76,8 @@ def _dict_to_message(data: dict[str, Any]) -> Any:
 
 def build_tool_loop_graph(
     *,
-    provider: Any,
-    tool_registry: Any,
+    provider: BaseLLMProvider,
+    tool_registry: ToolRegistry,
     max_iterations: int = 5,
 ) -> Any:
     """Compile a LangGraph model↔tools loop.
@@ -92,17 +95,13 @@ def build_tool_loop_graph(
 
         raise MissingExtraError("ai", feature="LangGraph", cause=exc) from exc
 
-    from openfatture.ai.domain.message import Message, Role
-
     def _tool_schemas() -> list[dict[str, Any]]:
-        if getattr(provider, "provider_name", "") == "anthropic":
-            schemas: list[dict[str, Any]] = list(tool_registry.get_anthropic_tools())
-            return schemas
-        openai_schemas: list[dict[str, Any]] = list(tool_registry.get_openai_functions())
-        return openai_schemas
+        if provider.provider_name == "anthropic":
+            return list(tool_registry.get_anthropic_tools())
+        return list(tool_registry.get_openai_functions())
 
     def _tool_choice() -> Any:
-        if getattr(provider, "provider_name", "") == "anthropic":
+        if provider.provider_name == "anthropic":
             return {"type": "auto"}
         return "auto"
 
@@ -110,11 +109,12 @@ def build_tool_loop_graph(
         messages = [_dict_to_message(m) for m in state.get("messages") or []]
         if not messages and state.get("user_input"):
             messages = [Message(role=Role.USER, content=state["user_input"])]
+        use_tools = provider.supports_tools
         response = await provider.generate(
             messages=messages,
             system_prompt=state.get("system_prompt"),
-            tools=_tool_schemas() if getattr(provider, "supports_tools", False) else None,
-            tool_choice=_tool_choice() if getattr(provider, "supports_tools", False) else None,
+            tools=_tool_schemas() if use_tools else None,
+            tool_choice=_tool_choice() if use_tools else None,
         )
         assistant_msg: dict[str, Any] = {
             "role": "assistant",
@@ -136,9 +136,8 @@ def build_tool_loop_graph(
         if not new_messages and state.get("user_input"):
             new_messages.append({"role": "user", "content": state["user_input"]})
         new_messages.append(assistant_msg)
-        tokens = int(getattr(response.usage, "total_tokens", 0) or 0) + int(
-            state.get("tokens") or 0
-        )
+        usage_tokens = response.usage.total_tokens if response.usage is not None else 0
+        tokens = int(usage_tokens or 0) + int(state.get("tokens") or 0)
         return {
             **state,
             "messages": new_messages,
@@ -245,18 +244,18 @@ def build_tool_loop_graph(
     return compiled
 
 
-def build_assistant_graph(runtime: Any) -> Any:
+def build_assistant_graph(runtime: _RuntimeProviderAccess) -> Any:
     """Build a multi-node tool-loop graph from an :class:`AssistantRuntime`.
 
-    Falls back to a single-node graph if the runtime has no tool registry/provider.
+    Uses provider/registry primitives only — never ``runtime.run`` — so the
+    graph cannot re-enter the product facade (backend circularity).
     """
-    provider = getattr(runtime, "_provider", None)
-    agent = getattr(runtime, "_agent", None)
-    registry = getattr(agent, "tool_registry", None) if agent is not None else None
-    if provider is not None and registry is not None and getattr(provider, "supports_tools", False):
+    provider: BaseLLMProvider = runtime._provider
+    registry: ToolRegistry = runtime._tool_registry
+    if provider.supports_tools:
         return build_tool_loop_graph(provider=provider, tool_registry=registry)
 
-    # Fallback: single-node delegation (streaming/non-tool providers)
+    # Fallback: single-node plain generation (no tools / no native tool support)
     require_extra("ai", feature="LangGraph assistant graph")
     from langgraph.graph import END, StateGraph
 
@@ -268,13 +267,16 @@ def build_assistant_graph(runtime: Any) -> Any:
         tokens: int
 
     async def run_turn(state: SimpleState) -> SimpleState:
-        response = await runtime.run(state["user_input"])
+        response = await provider.generate(
+            messages=[Message(role=Role.USER, content=state["user_input"])],
+        )
+        tokens = response.usage.total_tokens if response.usage is not None else 0
         return {
             "user_input": state["user_input"],
             "content": response.content or "",
-            "status": getattr(response.status, "value", str(response.status)),
+            "status": response.status.value,
             "error": response.error,
-            "tokens": int(getattr(response.usage, "total_tokens", 0) or 0),
+            "tokens": int(tokens or 0),
         }
 
     graph = StateGraph(SimpleState)

--- a/openfatture/ai/runtime/graph_backend.py
+++ b/openfatture/ai/runtime/graph_backend.py
@@ -1,0 +1,295 @@
+"""LangGraph product backend for the assistant runtime.
+
+Implements the same turn contract as ChatAgent (AgentResponse + StreamEvent)
+without re-entering :class:`AssistantRuntime` from graph nodes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+from openfatture.ai.domain.context import ChatContext
+from openfatture.ai.domain.message import Role
+from openfatture.ai.domain.response import AgentResponse, ResponseStatus, UsageMetrics
+from openfatture.ai.providers.base import BaseLLMProvider
+from openfatture.ai.runtime.constants import DEFAULT_TOOL_MAX_ITERATIONS
+from openfatture.ai.runtime.prompt import build_chat_messages, build_chat_system_prompt
+from openfatture.ai.streaming.events import StreamEvent
+from openfatture.ai.tools.registry import ToolRegistry
+from openfatture.platform.config import DebugConfig
+from openfatture.platform.extras import require_extra
+from openfatture.platform.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class GraphAssistantBackend:
+    """Product orchestration path backed by a model↔tools StateGraph."""
+
+    def __init__(
+        self,
+        *,
+        provider: BaseLLMProvider,
+        tool_registry: ToolRegistry,
+        enable_tools: bool = True,
+        max_iterations: int = DEFAULT_TOOL_MAX_ITERATIONS,
+        debug_config: DebugConfig | None = None,
+        temperature: float = 0.7,
+        max_tokens: int = 1500,
+    ) -> None:
+        require_extra("ai", feature="LangGraph assistant backend")
+        self.provider = provider
+        self.tool_registry = tool_registry
+        self.enable_tools = enable_tools
+        self.max_iterations = max_iterations
+        self.debug_config = debug_config
+        self.temperature = temperature
+        self.max_tokens = max_tokens
+        self._compiled_tool_graph: Any | None = None
+
+    def prepare_context(self, context: ChatContext) -> ChatContext:
+        """Ensure ``available_tools`` is populated when tools are enabled."""
+        if self.enable_tools and not context.available_tools:
+            context.available_tools = [t.name for t in self.tool_registry.list_tools()]
+        return context
+
+    def _use_native_tools(self, context: ChatContext) -> bool:
+        return self.enable_tools and self.provider.supports_tools and bool(context.available_tools)
+
+    def _use_react(self, context: ChatContext) -> bool:
+        return (
+            self.enable_tools and not self.provider.supports_tools and bool(context.available_tools)
+        )
+
+    def _get_tool_graph(self) -> Any:
+        if self._compiled_tool_graph is None:
+            from openfatture.ai.runtime.graph import build_tool_loop_graph
+
+            self._compiled_tool_graph = build_tool_loop_graph(
+                provider=self.provider,
+                tool_registry=self.tool_registry,
+                max_iterations=self.max_iterations,
+            )
+        return self._compiled_tool_graph
+
+    def _initial_tool_state(self, context: ChatContext) -> dict[str, Any]:
+        system_prompt = build_chat_system_prompt(context, enable_tools=self.enable_tools)
+        # Graph keeps system prompt out-of-band; seed with user (+ history sans system).
+        history_messages = build_chat_messages(
+            context, enable_tools=self.enable_tools, include_system=False
+        )
+        messages: list[dict[str, Any]] = []
+        for msg in history_messages:
+            entry: dict[str, Any] = {
+                "role": msg.role.value,
+                "content": msg.content or "",
+            }
+            if msg.tool_calls:
+                entry["tool_calls"] = msg.tool_calls
+            if msg.tool_call_id:
+                entry["tool_call_id"] = msg.tool_call_id
+            if msg.name:
+                entry["name"] = msg.name
+            messages.append(entry)
+        return {
+            "user_input": context.user_input,
+            "system_prompt": system_prompt,
+            "messages": messages,
+            "iteration": 0,
+            "max_iterations": self.max_iterations,
+            "tool_results": [],
+            "content": "",
+            "status": "",
+            "error": None,
+            "tokens": 0,
+        }
+
+    def _state_to_response(self, state: dict[str, Any]) -> AgentResponse:
+        status_raw = state.get("status") or "final"
+        if state.get("error"):
+            status = ResponseStatus.ERROR
+        elif status_raw == "final":
+            status = ResponseStatus.SUCCESS
+        else:
+            status = ResponseStatus.PARTIAL
+        tokens = int(state.get("tokens") or 0)
+        tool_results = list(state.get("tool_results") or [])
+        error = state.get("error")
+        return AgentResponse(
+            content=str(state.get("content") or ""),
+            status=status,
+            agent_name="chat_assistant",
+            model=self.provider.model,
+            provider=self.provider.provider_name,
+            usage=UsageMetrics(total_tokens=tokens),
+            error=str(error) if error is not None else None,
+            metadata={
+                "orchestrator": "langgraph_tool_loop",
+                "tool_results": tool_results,
+                "iterations": state.get("iteration"),
+            },
+        )
+
+    async def _run_plain(self, context: ChatContext) -> AgentResponse:
+        messages = build_chat_messages(context, enable_tools=self.enable_tools)
+        system: str | None = None
+        chat_messages = messages
+        if messages and messages[0].role == Role.SYSTEM:
+            system = messages[0].content
+            chat_messages = messages[1:]
+        response: AgentResponse = await self.provider.generate(
+            messages=chat_messages,
+            system_prompt=system,
+            temperature=self.temperature,
+            max_tokens=self.max_tokens,
+        )
+        response.agent_name = "chat_assistant"
+        response.metadata["orchestrator"] = "langgraph_plain"
+        return response
+
+    async def _run_react(self, context: ChatContext) -> AgentResponse:
+        from openfatture.ai.orchestration.react import ReActOrchestrator
+
+        orchestrator = ReActOrchestrator(
+            provider=self.provider,
+            tool_registry=self.tool_registry,
+            max_iterations=self.max_iterations,
+            debug_config=self.debug_config,
+        )
+        final_answer = await orchestrator.execute(context)
+        response = AgentResponse(
+            content=final_answer,
+            status=ResponseStatus.SUCCESS,
+            agent_name="chat_assistant",
+            model=self.provider.model,
+            provider=self.provider.provider_name,
+        )
+        response.metadata["orchestrator"] = "langgraph_react"
+        response.metadata["orchestrator_metrics"] = orchestrator.get_metrics()
+        return response
+
+    async def _run_tool_graph(self, context: ChatContext) -> AgentResponse:
+        graph = self._get_tool_graph()
+        state = await graph.ainvoke(self._initial_tool_state(context))
+        if not isinstance(state, dict):
+            return AgentResponse(
+                content="",
+                status=ResponseStatus.ERROR,
+                agent_name="chat_assistant",
+                error="LangGraph returned a non-dict state",
+            )
+        return self._state_to_response(state)
+
+    async def run(self, context: ChatContext) -> AgentResponse:
+        """Execute one assistant turn via the LangGraph product path."""
+        context = self.prepare_context(context)
+        if not context.user_input or not str(context.user_input).strip():
+            return AgentResponse(
+                content="",
+                status=ResponseStatus.ERROR,
+                agent_name="chat_assistant",
+                error="Input utente richiesto",
+            )
+        if len(context.user_input) > 5000:
+            return AgentResponse(
+                content="",
+                status=ResponseStatus.ERROR,
+                agent_name="chat_assistant",
+                error="Input troppo lungo (max 5000 caratteri)",
+            )
+
+        if self._use_native_tools(context):
+            logger.info(
+                "langgraph_native_tools",
+                provider=self.provider.provider_name,
+                tools=len(context.available_tools),
+            )
+            return await self._run_tool_graph(context)
+        if self._use_react(context):
+            logger.info(
+                "langgraph_react_fallback",
+                provider=self.provider.provider_name,
+                tools=len(context.available_tools),
+            )
+            return await self._run_react(context)
+        logger.info("langgraph_plain", provider=self.provider.provider_name)
+        return await self._run_plain(context)
+
+    async def stream(self, context: ChatContext) -> AsyncIterator[StreamEvent]:
+        """Stream one turn as typed events (node-granularity for the tool graph).
+
+        Token-level model streaming is not required for parity v1; the CLI
+        receives progressive tool lifecycle events and final content.
+        """
+        context = self.prepare_context(context)
+
+        if self._use_react(context):
+            from openfatture.ai.orchestration.react import ReActOrchestrator
+
+            orchestrator = ReActOrchestrator(
+                provider=self.provider,
+                tool_registry=self.tool_registry,
+                max_iterations=self.max_iterations,
+                debug_config=self.debug_config,
+            )
+            async for chunk in orchestrator.stream(context):
+                if isinstance(chunk, str):
+                    yield StreamEvent.content(chunk)
+                elif isinstance(chunk, StreamEvent):
+                    yield chunk
+                else:
+                    yield StreamEvent.content(str(chunk))
+            return
+
+        if not self._use_native_tools(context):
+            response = await self._run_plain(context)
+            if response.content:
+                yield StreamEvent.content(response.content)
+            return
+
+        graph = self._get_tool_graph()
+        initial = self._initial_tool_state(context)
+        seen_tool_count = 0
+        emitted_final_content = False
+        merged: dict[str, Any] = dict(initial)
+
+        async for update in graph.astream(initial, stream_mode="updates"):
+            if not isinstance(update, dict):
+                continue
+            for node_name, delta in update.items():
+                if not isinstance(delta, dict):
+                    continue
+                merged = {**merged, **delta}
+                if node_name == "call_tools":
+                    results = delta.get("tool_results") or []
+                    if not isinstance(results, list):
+                        continue
+                    for entry in results[seen_tool_count:]:
+                        if not isinstance(entry, dict):
+                            continue
+                        name = str(entry.get("tool") or "unknown")
+                        params = entry.get("parameters") or {}
+                        if not isinstance(params, dict):
+                            params = {}
+                        yield StreamEvent.tool_start(name, parameters=params)
+                        if entry.get("success"):
+                            yield StreamEvent.tool_result(name, result=entry.get("result"))
+                        else:
+                            yield StreamEvent.tool_error(
+                                name, error=str(entry.get("result") or "tool failed")
+                            )
+                    seen_tool_count = len(results)
+                elif node_name == "call_model":
+                    content = str(delta.get("content") or "")
+                    status = delta.get("status")
+                    if status == "final" and content:
+                        emitted_final_content = True
+                        yield StreamEvent.content(content)
+                    elif status == "tool_calls":
+                        yield StreamEvent.status("Calling tools…")
+
+        if not emitted_final_content:
+            content = str(merged.get("content") or "")
+            if content:
+                yield StreamEvent.content(content)

--- a/openfatture/ai/runtime/prompt.py
+++ b/openfatture/ai/runtime/prompt.py
@@ -1,0 +1,120 @@
+"""Shared chat prompt builders for product backends (chat + langgraph).
+
+Keeps system prompt and message assembly identical so backend parity tests
+compare orchestration, not copy-paste drift.
+"""
+
+from __future__ import annotations
+
+from openfatture.ai.domain.context import ChatContext
+from openfatture.ai.domain.message import Message, Role
+from openfatture.platform.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def build_chat_system_prompt(context: ChatContext, *, enable_tools: bool = True) -> str:
+    """Build the product assistant system prompt with optional tool/context hints."""
+    parts = [
+        "Sei un assistente AI specializzato per OpenFatture, un sistema di "
+        "fatturazione elettronica italiana.",
+        "",
+        "Il tuo ruolo è:",
+        "- Rispondere a domande su fatture e clienti",
+        "- Fornire statistiche e insights",
+        "- Guidare l'utente attraverso i workflow",
+        "- Eseguire azioni tramite tools quando necessario",
+        "",
+        "Regole:",
+        "- Usa un tono professionale ma friendly",
+        "- Rispondi in italiano (salvo richiesta diversa)",
+        "- Se non hai informazioni sufficienti, chiedi chiarimenti",
+        "- Prima di eseguire azioni distruttive, chiedi conferma",
+        "- Cita i dati specifici quando disponibili (numeri, date, importi)",
+    ]
+
+    if context.current_year_stats:
+        stats = context.current_year_stats
+        parts.extend(
+            [
+                "",
+                "Contesto corrente:",
+                f"- Anno: {stats.get('anno', 'N/A')}",
+                f"- Fatture totali: {stats.get('totale_fatture', 0)}",
+                f"- Importo totale: €{stats.get('importo_totale', 0):.2f}",
+            ]
+        )
+
+    if enable_tools and context.available_tools:
+        parts.extend(
+            [
+                "",
+                "Strumenti disponibili:",
+                f"- Hai accesso a {len(context.available_tools)} tools",
+                "- Usa i tools per recuperare dati o eseguire azioni",
+                "- I tools includono: ricerca fatture, statistiche, info clienti",
+            ]
+        )
+
+    if context.relevant_documents:
+        parts.extend(
+            [
+                "",
+                "Documenti rilevanti dal sistema (fatture correlate):",
+            ]
+        )
+        for doc in context.relevant_documents[:5]:
+            parts.append(f"- {doc}")
+
+    if context.knowledge_snippets:
+        parts.extend(
+            [
+                "",
+                "Fonti normative e note operative da consultare (cita come [numero]):",
+            ]
+        )
+        for idx, snippet in enumerate(context.knowledge_snippets[:5], 1):
+            citation = snippet.get("citation") or snippet.get("source") or f"Fonte {idx}"
+            excerpt = snippet.get("excerpt", "")
+            parts.append(f"[{idx}] {citation} — {excerpt}")
+
+        parts.extend(
+            [
+                "",
+                "Usa le fonti sopra per supportare la risposta e indica il riferimento con [numero].",
+            ]
+        )
+
+    return "\n".join(parts)
+
+
+def build_chat_messages(
+    context: ChatContext,
+    *,
+    enable_tools: bool = True,
+    include_system: bool = True,
+) -> list[Message]:
+    """Build the message list for one assistant turn (system + history + user)."""
+    messages: list[Message] = []
+
+    if include_system:
+        messages.append(
+            Message(
+                role=Role.SYSTEM,
+                content=build_chat_system_prompt(context, enable_tools=enable_tools),
+            )
+        )
+
+    for msg in context.conversation_history.get_messages(include_system=False):
+        messages.append(msg)
+
+    if not messages or messages[-1].role != Role.USER:
+        messages.append(Message(role=Role.USER, content=context.user_input))
+
+    logger.debug(
+        "chat_prompt_built",
+        total_messages=len(messages),
+        history_messages=len(context.conversation_history.messages),
+        tools=len(context.available_tools),
+    )
+    return messages

--- a/openfatture/ai/runtime/service.py
+++ b/openfatture/ai/runtime/service.py
@@ -3,20 +3,39 @@
 This is the only product-supported orchestration path for natural-language
 business operations. Interactive sessions optionally persist via the
 file-backed session store.
+
+Backends (settings ``assistant_backend``):
+- ``chat`` → ChatAgent tool loop (default)
+- ``langgraph`` → GraphAssistantBackend (opt-in product path)
 """
 
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
+from openfatture.ai.agents.chat_agent import ChatAgent
 from openfatture.ai.domain.context import ChatContext
 from openfatture.ai.domain.message import ConversationHistory, Message, Role
 from openfatture.ai.domain.response import AgentResponse
+from openfatture.ai.providers.base import BaseLLMProvider
+from openfatture.ai.providers.factory import create_provider
+from openfatture.ai.runtime.constants import (
+    ASSISTANT_BACKEND_CHAT,
+    ASSISTANT_BACKEND_LANGGRAPH,
+    AssistantBackendName,
+    resolve_backend_id,
+)
 from openfatture.ai.streaming.events import StreamEvent
+from openfatture.ai.tools.registry import ToolRegistry, get_tool_registry
 from openfatture.platform.config import DebugConfig, Settings, get_settings
 from openfatture.platform.extras import require_extra
 from openfatture.platform.logging import get_logger
+
+if TYPE_CHECKING:
+    from openfatture.ai.runtime.graph_backend import GraphAssistantBackend
+    from openfatture.ai.session.models import ChatSession
+    from openfatture.ai.session.store import SessionStore
 
 logger = get_logger(__name__)
 
@@ -34,35 +53,67 @@ def _history_from_dicts(items: list[dict[str, str]] | None) -> ConversationHisto
     return history
 
 
+def _resolve_backend_name(
+    backend: AssistantBackendName | None, settings: Settings
+) -> AssistantBackendName:
+    """Map ctor override or settings to a validated backend name."""
+    if backend == ASSISTANT_BACKEND_LANGGRAPH:
+        return ASSISTANT_BACKEND_LANGGRAPH
+    if backend == ASSISTANT_BACKEND_CHAT:
+        return ASSISTANT_BACKEND_CHAT
+    if settings.assistant_backend == ASSISTANT_BACKEND_LANGGRAPH:
+        return ASSISTANT_BACKEND_LANGGRAPH
+    return ASSISTANT_BACKEND_CHAT
+
+
 class AssistantRuntime:
     """Single assistant entry used by ``openfatture assistant`` / interactive."""
 
     def __init__(
         self,
         *,
-        provider: Any | None = None,
+        provider: BaseLLMProvider | None = None,
         settings: Settings | None = None,
         enable_streaming: bool = True,
         enable_tools: bool = True,
         debug_config: DebugConfig | None = None,
         session_id: str | None = None,
         persist_session: bool = False,
+        backend: AssistantBackendName | None = None,
     ) -> None:
         require_extra("ai", feature="the business assistant")
-        from openfatture.ai.agents.chat_agent import ChatAgent
-        from openfatture.ai.providers.factory import create_provider
 
         self.settings = settings or get_settings()
-        self._provider = provider or create_provider()
+        self._provider: BaseLLMProvider = provider or create_provider()
+        self.enable_tools = enable_tools
+        self.enable_streaming = enable_streaming
+        self.debug_config = debug_config or self.settings.debug_config
+        self._tool_registry: ToolRegistry = get_tool_registry()
+
+        self._backend_name = _resolve_backend_name(backend, self.settings)
+        self._backend_id = resolve_backend_id(self._backend_name)
+
         self._agent = ChatAgent(
             provider=self._provider,
+            tool_registry=self._tool_registry,
             enable_streaming=enable_streaming,
             enable_tools=enable_tools,
-            debug_config=debug_config or self.settings.debug_config,
+            debug_config=self.debug_config,
         )
+        self._graph_backend: GraphAssistantBackend | None = None
+        if self._backend_name == ASSISTANT_BACKEND_LANGGRAPH:
+            from openfatture.ai.runtime.graph_backend import GraphAssistantBackend
+
+            self._graph_backend = GraphAssistantBackend(
+                provider=self._provider,
+                tool_registry=self._tool_registry,
+                enable_tools=enable_tools,
+                debug_config=self.debug_config,
+            )
+
         self.persist_session = persist_session
-        self._session = None
-        self._session_store = None
+        self._session: ChatSession | None = None
+        self._session_store: SessionStore | None = None
         if persist_session:
             from openfatture.ai.session import ChatSession, get_session_store
 
@@ -76,15 +127,21 @@ class AssistantRuntime:
         logger.info(
             "assistant_runtime_ready",
             provider=self._provider.provider_name,
-            model=getattr(self._provider, "model", None),
-            backend="chat_agent_tool_loop",
+            model=self._provider.model,
+            backend=self._backend_id,
+            assistant_backend=self._backend_name,
             persist_session=persist_session,
         )
 
     @property
     def backend(self) -> str:
         """Orchestration backend identifier (stable for status/metrics)."""
-        return "chat_agent_tool_loop"
+        return self._backend_id
+
+    @property
+    def assistant_backend(self) -> AssistantBackendName:
+        """Settings-level backend name (``chat`` | ``langgraph``)."""
+        return self._backend_name
 
     @property
     def session_id(self) -> str | None:
@@ -95,19 +152,22 @@ class AssistantRuntime:
         user_input: str,
         history: list[dict[str, str]] | ConversationHistory | None = None,
     ) -> ChatContext:
-        conv: ConversationHistory | None
+        conv: ConversationHistory
         if isinstance(history, ConversationHistory):
             conv = history
         elif history is not None:
-            conv = _history_from_dicts(history)
+            conv = _history_from_dicts(history) or ConversationHistory()
         elif self._session is not None:
-            # Rebuild history from persisted session messages
             conv = ConversationHistory()
             for msg in self._session.messages:
                 conv.add_message(Message(role=msg.role, content=msg.content))
         else:
             conv = ConversationHistory()
-        return ChatContext(user_input=user_input, conversation_history=conv)
+        context = ChatContext(user_input=user_input, conversation_history=conv)
+        # Populate tools for both backends so native/ReAct paths actually run.
+        if self.enable_tools and not context.available_tools:
+            context.available_tools = [t.name for t in self._tool_registry.list_tools()]
+        return context
 
     def _persist_turn(
         self, user_input: str, assistant_content: str, response: AgentResponse | None = None
@@ -122,8 +182,8 @@ class AssistantRuntime:
             cost = response.usage.estimated_cost_usd
         self._session.add_assistant_message(
             assistant_content,
-            provider=getattr(self._provider, "provider_name", None),
-            model=getattr(self._provider, "model", None),
+            provider=self._provider.provider_name,
+            model=self._provider.model,
             tokens=tokens,
             cost=cost,
         )
@@ -138,7 +198,10 @@ class AssistantRuntime:
     ) -> AgentResponse:
         """Run one assistant turn and return a full response."""
         context = self._context(user_input, history)
-        response = await self._agent.execute(context)
+        if self._graph_backend is not None:
+            response = await self._graph_backend.run(context)
+        else:
+            response = await self._agent.execute(context)
         self._persist_turn(user_input, response.content or "", response)
         return response
 
@@ -151,8 +214,12 @@ class AssistantRuntime:
         """Stream one assistant turn as typed stream events."""
         context = self._context(user_input, history)
         answer_parts: list[str] = []
-        async for item in self._agent.execute_stream(context):
-            if hasattr(item, "is_content") and item.is_content():
+        if self._graph_backend is not None:
+            stream_iter: AsyncIterator[StreamEvent] = self._graph_backend.stream(context)
+        else:
+            stream_iter = self._agent.execute_stream(context)
+        async for item in stream_iter:
+            if item.is_content():
                 answer_parts.append(item.get_text())
             yield item
         self._persist_turn(user_input, "".join(answer_parts), None)

--- a/openfatture/cli/commands/status.py
+++ b/openfatture/cli/commands/status.py
@@ -77,6 +77,14 @@ def _build_status() -> dict[str, Any]:
             p.name for p in hooks_dir.iterdir() if p.is_file() and not p.name.startswith(".")
         )
     readiness = _readiness(settings, extras)
+    # Keep mapping inline so core-only installs never import the AI package.
+    assistant_backend = str(getattr(settings, "assistant_backend", "chat") or "chat")
+    _backend_ids = {
+        "chat": "chat_agent_tool_loop",
+        "langgraph": "langgraph_tool_loop",
+    }
+    assistant_backend_id = _backend_ids.get(assistant_backend, "chat_agent_tool_loop")
+
     return {
         "version": __version__,
         "database": str(settings.database_url),
@@ -85,6 +93,8 @@ def _build_status() -> dict[str, Any]:
         "ai_provider": settings.ai_provider,
         "ai_model": settings.ai_model,
         "ai_api_key_configured": bool(settings.ai_api_key),
+        "assistant_backend": assistant_backend,
+        "assistant_backend_id": assistant_backend_id,
         "readiness": readiness,
         "extras": extras,
         "extensions": {
@@ -100,6 +110,7 @@ def _build_status() -> dict[str, Any]:
             "lightning_allow_mock": settings.lightning_allow_mock,
             "lightning_rpc_ready": False,  # true only when LND gRPC stubs are wired
             "assistant_available": bool(extras.get("ai")),
+            "assistant_backend": assistant_backend,
             "rag_auto_update_default": False,  # OPENFATTURE_RAG_AUTO_UPDATE_ENABLED default
         },
         "limitations": {
@@ -142,6 +153,8 @@ def status(json_output: bool = typer.Option(False, "--json", help="Emit status a
         "ai_provider",
         "ai_model",
         "ai_api_key_configured",
+        "assistant_backend",
+        "assistant_backend_id",
     ):
         table.add_row(key.replace("_", " ").title(), str(data[key]))
     console.print(table)

--- a/openfatture/platform/config.py
+++ b/openfatture/platform/config.py
@@ -1,6 +1,7 @@
 """Configuration management for OpenFatture."""
 
 from pathlib import Path
+from typing import Literal
 
 from platformdirs import PlatformDirs
 from pydantic import Field, field_validator
@@ -254,6 +255,15 @@ class Settings(BaseSettings):
     ai_max_tokens: int = Field(default=2000, description="AI max tokens")
 
     # AI Chat Assistant
+    assistant_backend: Literal["chat", "langgraph"] = Field(
+        default="chat",
+        description=(
+            "Product assistant orchestration backend: "
+            "'chat' (ChatAgent / NativeToolOrchestrator) or "
+            "'langgraph' (StateGraph model↔tools loop). Default remains chat until "
+            "parity gates flip it."
+        ),
+    )
     ai_chat_enabled: bool = Field(
         default=True,
         description="Enable AI chat assistant",

--- a/tests/ai/test_assistant_backend_parity.py
+++ b/tests/ai/test_assistant_backend_parity.py
@@ -1,0 +1,246 @@
+"""Parity contracts: chat vs langgraph product backends.
+
+Same mock provider/registry fixtures drive both paths. Failures block advertising
+langgraph as a ready product backend.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from openfatture.ai.domain.response import AgentResponse, ResponseStatus, ToolCall, UsageMetrics
+from openfatture.ai.runtime.constants import BACKEND_CHAT, BACKEND_LANGGRAPH
+from openfatture.ai.streaming.events import StreamEventType
+from openfatture.ai.tools.models import ToolResult
+
+
+def _final(content: str = "done") -> AgentResponse:
+    return AgentResponse(
+        content=content,
+        status=ResponseStatus.SUCCESS,
+        usage=UsageMetrics(total_tokens=2, estimated_cost_usd=0.0),
+    )
+
+
+def _with_tool(name: str = "search_invoices") -> AgentResponse:
+    return AgentResponse(
+        content="",
+        status=ResponseStatus.SUCCESS,
+        tool_calls=[ToolCall(id="1", name=name, arguments={"limit": 5})],
+        usage=UsageMetrics(total_tokens=3, estimated_cost_usd=0.0),
+    )
+
+
+def _provider_and_registry(
+    *,
+    supports_tools: bool = True,
+    generate_side_effect: Any = None,
+) -> tuple[MagicMock, MagicMock]:
+    provider = MagicMock()
+    provider.provider_name = "openai"
+    provider.model = "gpt-test"
+    provider.supports_tools = supports_tools
+    if generate_side_effect is None:
+        provider.generate = AsyncMock(return_value=_final("hello"))
+    else:
+        # Fresh list copy so AsyncMock side_effect is not shared across runs.
+        provider.generate = AsyncMock(side_effect=list(generate_side_effect))
+
+    registry = MagicMock()
+    registry.get_openai_functions.return_value = [
+        {"type": "function", "function": {"name": "search_invoices", "parameters": {}}}
+    ]
+    registry.get_anthropic_tools.return_value = []
+    tool = MagicMock()
+    tool.name = "search_invoices"
+    registry.list_tools.return_value = [tool]
+    registry.execute_tool = AsyncMock(
+        return_value=ToolResult(
+            success=True,
+            data={"count": 1},
+            error=None,
+            tool_name="search_invoices",
+        )
+    )
+    return provider, registry
+
+
+def _runtime(backend: str, provider: MagicMock, registry: MagicMock) -> Any:
+    with (
+        patch("openfatture.platform.extras.require_extra"),
+        patch("openfatture.ai.providers.factory.create_provider", return_value=provider),
+        patch("openfatture.ai.tools.registry.get_tool_registry", return_value=registry),
+        patch("openfatture.ai.runtime.service.get_tool_registry", return_value=registry),
+    ):
+        from openfatture.ai.runtime import create_assistant_runtime
+
+        return create_assistant_runtime(backend=backend, provider=provider, enable_tools=True)
+
+
+@pytest.mark.asyncio
+async def test_default_backend_is_chat() -> None:
+    provider, registry = _provider_and_registry()
+    runtime = _runtime("chat", provider, registry)
+    assert runtime.backend == BACKEND_CHAT
+    assert runtime.assistant_backend == "chat"
+
+
+@pytest.mark.asyncio
+async def test_langgraph_backend_id() -> None:
+    provider, registry = _provider_and_registry()
+    runtime = _runtime("langgraph", provider, registry)
+    assert runtime.backend == BACKEND_LANGGRAPH
+    assert runtime.assistant_backend == "langgraph"
+
+
+@pytest.mark.asyncio
+async def test_parity_zero_tools_content() -> None:
+    """Zero tool_calls → same final content on both backends."""
+    provider_chat, registry_chat = _provider_and_registry(
+        generate_side_effect=[_final("hello world")]
+    )
+    provider_lg, registry_lg = _provider_and_registry(generate_side_effect=[_final("hello world")])
+    # No tools on registry so both use plain generation
+    registry_chat.list_tools.return_value = []
+    registry_lg.list_tools.return_value = []
+
+    chat = _runtime("chat", provider_chat, registry_chat)
+    lg = _runtime("langgraph", provider_lg, registry_lg)
+
+    r_chat = await chat.run("hi")
+    r_lg = await lg.run("hi")
+    assert r_chat.content == r_lg.content == "hello world"
+    assert r_chat.status == r_lg.status == ResponseStatus.SUCCESS
+
+
+@pytest.mark.asyncio
+async def test_parity_one_tool_round_trip() -> None:
+    """Model → tool → final: tool name and success surface match."""
+    provider_chat, registry_chat = _provider_and_registry(
+        generate_side_effect=[_with_tool(), _final("Found invoices")]
+    )
+    provider_lg, registry_lg = _provider_and_registry(
+        generate_side_effect=[_with_tool(), _final("Found invoices")]
+    )
+
+    chat = _runtime("chat", provider_chat, registry_chat)
+    lg = _runtime("langgraph", provider_lg, registry_lg)
+
+    r_chat = await chat.run("list invoices")
+    r_lg = await lg.run("list invoices")
+
+    assert r_chat.content == r_lg.content == "Found invoices"
+    assert registry_chat.execute_tool.await_count == 1
+    assert registry_lg.execute_tool.await_count == 1
+    assert provider_chat.generate.await_count == 2
+    assert provider_lg.generate.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_parity_max_iterations_cap() -> None:
+    """Both backends stop after max_iterations of continuous tool calls."""
+    # Always request tools → hit cap
+    side = [_with_tool() for _ in range(10)]
+    provider_chat, registry_chat = _provider_and_registry(generate_side_effect=list(side))
+    provider_lg, registry_lg = _provider_and_registry(generate_side_effect=list(side))
+
+    chat = _runtime("chat", provider_chat, registry_chat)
+    lg = _runtime("langgraph", provider_lg, registry_lg)
+
+    await chat.run("loop")
+    await lg.run("loop")
+
+    # Native orchestrator and graph both default to 5 iterations
+    assert provider_chat.generate.await_count == 5
+    assert provider_lg.generate.await_count == 5
+
+
+@pytest.mark.asyncio
+async def test_langgraph_stream_tool_event_order() -> None:
+    """Stream emits tool_start before tool_result, then final content."""
+    provider, registry = _provider_and_registry(
+        generate_side_effect=[_with_tool(), _final("Found invoices")]
+    )
+    runtime = _runtime("langgraph", provider, registry)
+
+    types: list[StreamEventType] = []
+    async for event in runtime.stream("list invoices"):
+        types.append(event.type)
+
+    assert StreamEventType.TOOL_START in types
+    assert StreamEventType.TOOL_RESULT in types
+    assert StreamEventType.CONTENT in types
+    assert types.index(StreamEventType.TOOL_START) < types.index(StreamEventType.TOOL_RESULT)
+    # Final content after tools
+    assert types.index(StreamEventType.TOOL_RESULT) < types.index(StreamEventType.CONTENT)
+
+
+@pytest.mark.asyncio
+async def test_langgraph_stream_zero_tools_has_content() -> None:
+    provider, registry = _provider_and_registry(generate_side_effect=[_final("plain")])
+    registry.list_tools.return_value = []
+    runtime = _runtime("langgraph", provider, registry)
+
+    events = [e async for e in runtime.stream("hi")]
+    assert any(e.type == StreamEventType.CONTENT for e in events)
+    assert any(e.data == "plain" for e in events if e.type == StreamEventType.CONTENT)
+
+
+@pytest.mark.asyncio
+async def test_session_persist_same_sequence(tmp_path: Path) -> None:
+    """Persist path records user + assistant messages for both backends."""
+    from openfatture.ai.session.file_store import FileSessionStore
+
+    async def _run(backend: str) -> list[str]:
+        provider, registry = _provider_and_registry(generate_side_effect=[_final(f"ok-{backend}")])
+        registry.list_tools.return_value = []
+        store = FileSessionStore(sessions_dir=tmp_path / backend)
+        with (
+            patch("openfatture.platform.extras.require_extra"),
+            patch("openfatture.ai.providers.factory.create_provider", return_value=provider),
+            patch("openfatture.ai.tools.registry.get_tool_registry", return_value=registry),
+            patch("openfatture.ai.runtime.service.get_tool_registry", return_value=registry),
+            patch("openfatture.ai.session.get_session_store", return_value=store),
+        ):
+            from openfatture.ai.runtime import create_assistant_runtime
+
+            runtime = create_assistant_runtime(
+                backend=backend, provider=provider, persist_session=True
+            )
+            await runtime.run("hello")
+            assert runtime.session_id is not None
+            loaded = store.load(runtime.session_id)
+            assert loaded is not None
+            return [
+                m.role.value if hasattr(m.role, "value") else str(m.role) for m in loaded.messages
+            ]
+
+    roles_chat = await _run("chat")
+    roles_lg = await _run("langgraph")
+    assert roles_chat == roles_lg
+    assert roles_chat[0] == "user"
+    assert roles_chat[1] == "assistant"
+
+
+@pytest.mark.asyncio
+async def test_error_tool_result_continues_to_final() -> None:
+    """Failed tool still allows a final model answer on langgraph path."""
+    provider, registry = _provider_and_registry(
+        generate_side_effect=[_with_tool(), _final("recovered")]
+    )
+    registry.execute_tool = AsyncMock(
+        return_value=ToolResult(
+            success=False,
+            data=None,
+            error="boom",
+            tool_name="search_invoices",
+        )
+    )
+    runtime = _runtime("langgraph", provider, registry)
+    result = await runtime.run("list")
+    assert result.content == "recovered"
+    assert registry.execute_tool.await_count == 1

--- a/tests/ai/test_assistant_runtime.py
+++ b/tests/ai/test_assistant_runtime.py
@@ -16,10 +16,12 @@ async def test_runtime_run_delegates_to_chat_agent() -> None:
         agent_name="chat",
         usage=UsageMetrics(total_tokens=1, estimated_cost_usd=0.0),
     )
+    empty_registry = MagicMock(list_tools=MagicMock(return_value=[]))
     with (
         patch("openfatture.platform.extras.require_extra"),
         patch("openfatture.ai.providers.factory.create_provider") as mock_prov,
-        patch("openfatture.ai.agents.chat_agent.ChatAgent") as mock_agent_cls,
+        patch("openfatture.ai.tools.registry.get_tool_registry", return_value=empty_registry),
+        patch("openfatture.ai.runtime.service.ChatAgent") as mock_agent_cls,
     ):
         mock_prov.return_value = MagicMock(provider_name="openai", model="gpt", supports_tools=True)
         agent = MagicMock()
@@ -33,15 +35,20 @@ async def test_runtime_run_delegates_to_chat_agent() -> None:
         assert result.content == "ok"
         agent.execute.assert_awaited_once()
         assert runtime.session_id is None
+        assert runtime.backend == "chat_agent_tool_loop"
 
 
 def test_build_assistant_graph_compiles() -> None:
+    empty_registry = MagicMock(list_tools=MagicMock(return_value=[]))
     with (
         patch("openfatture.platform.extras.require_extra"),
         patch("openfatture.ai.providers.factory.create_provider") as mock_prov,
-        patch("openfatture.ai.agents.chat_agent.ChatAgent"),
+        patch("openfatture.ai.tools.registry.get_tool_registry", return_value=empty_registry),
+        patch("openfatture.ai.runtime.service.ChatAgent"),
     ):
-        mock_prov.return_value = MagicMock(provider_name="openai", model="gpt")
+        mock_prov.return_value = MagicMock(
+            provider_name="openai", model="gpt", supports_tools=False
+        )
         from openfatture.ai.runtime import create_assistant_runtime
         from openfatture.ai.runtime.graph import build_assistant_graph
 
@@ -59,10 +66,12 @@ async def test_runtime_persist_session_saves_and_reloads(tmp_path: Path) -> None
         agent_name="chat",
         usage=UsageMetrics(total_tokens=2, estimated_cost_usd=0.0),
     )
+    empty_registry = MagicMock(list_tools=MagicMock(return_value=[]))
     with (
         patch("openfatture.platform.extras.require_extra"),
         patch("openfatture.ai.providers.factory.create_provider") as mock_prov,
-        patch("openfatture.ai.agents.chat_agent.ChatAgent") as mock_agent_cls,
+        patch("openfatture.ai.tools.registry.get_tool_registry", return_value=empty_registry),
+        patch("openfatture.ai.runtime.service.ChatAgent") as mock_agent_cls,
         patch("openfatture.ai.session.get_session_store") as mock_store_factory,
     ):
         from openfatture.ai.session.file_store import FileSessionStore

--- a/tests/ai/test_tool_loop_parity.py
+++ b/tests/ai/test_tool_loop_parity.py
@@ -73,14 +73,16 @@ async def test_graph_tool_round_trip_matches_shape() -> None:
 
 
 @pytest.mark.asyncio
-async def test_product_runtime_backend_is_chat_agent() -> None:
-    """Product path still reports chat_agent_tool_loop (B1-β)."""
+async def test_product_runtime_default_backend_is_chat() -> None:
+    """Default product path still reports chat_agent_tool_loop (B1-β default)."""
     with (
         patch("openfatture.platform.extras.require_extra"),
         patch("openfatture.ai.providers.factory.create_provider") as mock_prov,
-        patch("openfatture.ai.agents.chat_agent.ChatAgent") as mock_agent_cls,
+        patch("openfatture.ai.tools.registry.get_tool_registry") as mock_reg,
+        patch("openfatture.ai.runtime.service.ChatAgent") as mock_agent_cls,
     ):
         mock_prov.return_value = MagicMock(provider_name="openai", model="gpt")
+        mock_reg.return_value = MagicMock(list_tools=MagicMock(return_value=[]))
         agent = MagicMock()
         agent.execute = AsyncMock(return_value=_final("ok"))
         mock_agent_cls.return_value = agent
@@ -89,6 +91,7 @@ async def test_product_runtime_backend_is_chat_agent() -> None:
 
         runtime = create_assistant_runtime()
         assert runtime.backend == "chat_agent_tool_loop"
+        assert runtime.assistant_backend == "chat"
         response = await runtime.run("hello")
         assert response.content == "ok"
 


### PR DESCRIPTION
## Summary

Opt-in LangGraph product path behind the existing `AssistantRuntime` facade. **Default remains `chat`** (`chat_agent_tool_loop`). No new public CLI commands.

- `assistant_backend` setting / `ASSISTANT_BACKEND=chat|langgraph`
- `GraphAssistantBackend`: model↔tools StateGraph, ReAct when provider lacks native tools, plain generate otherwise
- Shared prompt helpers (`ai.runtime.prompt`) used by chat + langgraph
- Node-granularity `StreamEvent` streaming on the graph path
- Status exposes `assistant_backend` + `assistant_backend_id`
- Populates `context.available_tools` so native tool loops actually engage
- `build_assistant_graph` never re-enters `runtime.run`
- Typed contracts (`BaseLLMProvider`, `Protocol`); no `cast` / `type: ignore` / `noqa`

## Non-goals (this PR)

- Default flip to langgraph (later, after soak)
- Multi-agent workflows on CLI
- Token-level streaming inside graph model node (v1 is node-granularity)

## Test plan

- [x] `ruff check` + `mypy openfatture/ai/runtime`
- [x] Parity suite: `tests/ai/test_assistant_backend_parity.py`
- [x] Runtime / tool-loop / status readiness tests
- [ ] CI green on this PR
- [ ] Manual (optional): `ASSISTANT_BACKEND=langgraph openfatture assistant "…"`