### PR TITLE
feat(ai): default LangGraph backend and slim ChatAgent (2.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,23 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.1.0] - 2026-08-08
 
 ### Added
 
-- Opt-in LangGraph product assistant backend (`ASSISTANT_BACKEND=langgraph` /
-  `assistant_backend` setting). Default remains `chat`.
-- Shared chat prompt helpers (`ai.runtime.prompt`) used by both backends.
-- `GraphAssistantBackend` with `run` + node-granularity `stream` (`StreamEvent`).
-- Status fields `assistant_backend` and `assistant_backend_id`.
-- Parity tests: chat vs langgraph tool round-trips, max iterations, streaming
-  event order, session message sequence.
+- LangGraph is the **default** product assistant backend (`langgraph_tool_loop`).
+- Release notes: `docs/releases/v2.1.0.md`.
 
 ### Changed
 
-- `AssistantRuntime` resolves backend from settings/ctor; populates
-  `context.available_tools` so native tool loops actually engage.
-- `build_assistant_graph` no longer re-enters `runtime.run` (no circular facade).
+- Default `assistant_backend` / `ASSISTANT_BACKEND`: `chat` → **`langgraph`**.
+- `ChatAgent` slimmed: single tool-loop via `GraphAssistantBackend`; keeps
+  structured-output and shared prompt helpers. Rollback path: `ASSISTANT_BACKEND=chat`.
+- `AssistantRuntime` constructs only the selected backend (no always-on dual init).
+
+### Notes
+
+- Opt-in backend plumbing and parity tests shipped in 2.0.x unreleased work and
+  are now the product default.
 
 ## [2.0.2] - 2026-08-07
 

--- a/docs/AI_ARCHITECTURE.md
+++ b/docs/AI_ARCHITECTURE.md
@@ -11,16 +11,16 @@ CLI assistant / interactive
         v
 openfatture.ai.runtime.AssistantRuntime
         │
-        ├── assistant_backend=chat (default)
-        │     ChatAgent tool loop (status id: chat_agent_tool_loop)
-        │       ├── NativeToolOrchestrator  (providers with native tools)
-        │       └── ReActOrchestrator       (fallback / Ollama)
+        ├── assistant_backend=langgraph (default)
+        │     GraphAssistantBackend (status id: langgraph_tool_loop)
+        │       ├── StateGraph call_model ↔ call_tools
+        │       ├── ReAct when provider lacks native tools
+        │       └── node-granularity StreamEvent streaming
         │
-        └── assistant_backend=langgraph (opt-in)
-              GraphAssistantBackend (status id: langgraph_tool_loop)
-                ├── StateGraph call_model ↔ call_tools
-                ├── ReAct node when provider lacks native tools
-                └── node-granularity StreamEvent streaming
+        └── assistant_backend=chat (rollback)
+              ChatAgent (status id: chat_agent_tool_loop)
+                ├── structured output (output_schema)
+                └── tool/plain turns → same GraphAssistantBackend
         │
         v
 ToolRegistry → application services (billing.*) → storage
@@ -30,11 +30,11 @@ ToolRegistry → application services (billing.*) → storage
 # Preferred API for embedders / tests
 from openfatture.ai.runtime import create_assistant_runtime, run_assistant
 
-runtime = create_assistant_runtime()  # default: chat
+runtime = create_assistant_runtime()  # default: langgraph
 response = await runtime.run("Elenca le fatture non pagate")
 
-# Opt-in LangGraph product backend (or set ASSISTANT_BACKEND=langgraph)
-runtime = create_assistant_runtime(backend="langgraph")
+# Explicit rollback
+runtime = create_assistant_runtime(backend="chat")
 ```
 
 Interactive sessions can persist to the file session store
@@ -43,11 +43,12 @@ Interactive sessions can persist to the file session store
 loaded from the store (do not also pass a parallel in-memory history that
 duplicates turns).
 
-## LangGraph product backend (opt-in)
+## LangGraph product backend (default)
 
-`GraphAssistantBackend` is a first-class product path behind the same facade.
-Default remains **`chat`** until a later release flips the default after soak.
-Parity tests (`tests/ai/test_assistant_backend_parity.py`) gate readiness.
+`GraphAssistantBackend` is the product tool-loop. There is a **single**
+implementation for model↔tools / ReAct / plain turns; `ChatAgent` no longer
+maintains a parallel native orchestrator. Parity tests live in
+`tests/ai/test_assistant_backend_parity.py`.
 
 ```python
 from openfatture.ai.runtime.graph import build_assistant_graph
@@ -56,9 +57,8 @@ graph = build_assistant_graph(runtime)  # helper / tests; CLI uses runtime.backe
 await graph.ainvoke({"user_input": "..."})
 ```
 
-Set `ASSISTANT_BACKEND=langgraph` or `assistant_backend = "langgraph"` in
-config. Check with `openfatture status --json` (`assistant_backend`,
-`assistant_backend_id`).
+Rollback: `ASSISTANT_BACKEND=chat`. Inspect with `openfatture status --json`
+(`assistant_backend`, `assistant_backend_id`).
 
 ## Boundaries
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -59,7 +59,7 @@ uv sync --all-extras
 | `AI_MODEL` | Provider model name |
 | `AI_API_KEY` | Provider credential |
 | `AI_BASE_URL` | Local provider endpoint, such as Ollama |
-| `ASSISTANT_BACKEND` | Product assistant orchestration: `chat` (default) or `langgraph` (opt-in StateGraph tool loop) |
+| `ASSISTANT_BACKEND` | Product assistant orchestration: `langgraph` (default StateGraph tool loop) or `chat` (rollback) |
 
 Sensitive values should be provided through the environment or a protected
 local secrets file. Do not commit credentials.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # OpenFatture project status
 
-**Current version:** 2.0.2  
+**Current version:** 2.1.0  
 **Product posture:** CLI-first, with an interactive terminal mode for guided workflows  
 **Runtime:** Python 3.12+ and `uv`
 
@@ -36,11 +36,11 @@ fix the root cause instead.
 9. ~~D2: AI tools are adapters over application services~~
 10. ~~2.0.0 release notes and version bump~~
 
-## Current focus (post-2.0)
+## Current focus (post-2.1)
 
-1. **LangGraph product backend is opt-in** (`ASSISTANT_BACKEND=langgraph`);
-   default remains `chat` / `chat_agent_tool_loop`. Parity + stream tests gate
-   any future default flip. Multi-agent workflows stay non-CLI.
+1. **LangGraph is the default product backend** (`langgraph_tool_loop`);
+   `ASSISTANT_BACKEND=chat` remains a supported rollback. Multi-agent workflows
+   stay non-CLI.
 2. Lightning real LND gRPC **or** keep hard experimental posture
 3. Continue splitting oversized modules (`cash_flow_predictor`, ops facades;
    `ai.tools.registry` is already a package)

--- a/docs/releases/v2.1.0.md
+++ b/docs/releases/v2.1.0.md
@@ -1,0 +1,25 @@
+# OpenFatture 2.1.0
+
+## Highlights
+
+- **Default assistant backend is LangGraph** (`langgraph_tool_loop`).
+- **Single tool-loop implementation**: `GraphAssistantBackend` is the product
+  orchestrator; `ChatAgent` is slimmed to structured output + prompt helpers
+  and delegates tool/plain turns to the same graph backend.
+- Rollback remains available: `ASSISTANT_BACKEND=chat`.
+
+## Upgrade notes
+
+| Before (2.0.x) | After (2.1.0) |
+|----------------|---------------|
+| Default `assistant_backend=chat` | Default `assistant_backend=langgraph` |
+| Dual tool loops (ChatAgent native + graph helper) | One tool loop (`GraphAssistantBackend`) |
+
+No new public CLI commands. Set `ASSISTANT_BACKEND=chat` to force the rollback
+path. Inspect with `openfatture status --json` (`assistant_backend`,
+`assistant_backend_id`).
+
+## Verification
+
+- Parity tests: `tests/ai/test_assistant_backend_parity.py`
+- Default backend assertions in runtime / tool-loop tests

--- a/openfatture/__init__.py
+++ b/openfatture/__init__.py
@@ -5,6 +5,6 @@ A modern, CLI-first invoicing system with AI-powered workflows and full
 compliance with FatturaPA and SDI requirements.
 """
 
-__version__ = "2.0.2"
+__version__ = "2.1.0"
 __author__ = "Venere Labs"
 __license__ = "MIT"

--- a/openfatture/ai/agents/chat_agent.py
+++ b/openfatture/ai/agents/chat_agent.py
@@ -1,4 +1,13 @@
-"""Conversational Chat Agent with tool calling capabilities."""
+"""Conversational Chat Agent — prompt/context specialist + structured output.
+
+Tool orchestration for product traffic lives in
+:class:`~openfatture.ai.runtime.graph_backend.GraphAssistantBackend`.
+This agent keeps structured-output calls and shared prompt helpers; when used
+as the ``chat`` rollback backend it delegates tool/plain turns to the same
+graph backend so there is a single tool-loop implementation.
+"""
+
+from __future__ import annotations
 
 import json
 from collections.abc import AsyncIterator
@@ -7,9 +16,8 @@ from typing import Any
 from openfatture.ai.domain import AgentConfig, BaseAgent, Message
 from openfatture.ai.domain.context import ChatContext
 from openfatture.ai.domain.response import AgentResponse, ResponseStatus
-from openfatture.ai.orchestration.native_tools import NativeToolOrchestrator
-from openfatture.ai.orchestration.react import ReActOrchestrator
 from openfatture.ai.providers import BaseLLMProvider
+from openfatture.ai.runtime.constants import DEFAULT_TOOL_MAX_ITERATIONS
 from openfatture.ai.streaming import StreamEvent
 from openfatture.ai.tools import ToolRegistry, get_tool_registry
 from openfatture.platform.config import DebugConfig
@@ -21,28 +29,16 @@ logger = get_logger(__name__)
 
 class ChatAgent(BaseAgent[ChatContext]):
     """
-    General-purpose conversational agent with tool calling.
+    Conversational assistant agent for OpenFatture.
 
-    Specialized to use ChatContext for type-safe context handling.
+    Responsibilities:
+    - Input validation and context metadata
+    - Structured-output generation (``config.output_schema``)
+    - Prompt/system builders (shared with the LangGraph product path)
+    - Tool/plain/ReAct turns via :class:`GraphAssistantBackend` (single loop)
 
-    Features:
-    - Multi-turn conversations with memory
-    - Function/tool calling for actions (search invoices, get stats, etc.)
-    - Context enrichment with business data
-    - Streaming support (if provider supports it)
-    - Session management integration
-
-    The agent can:
-    - Answer questions about invoices and clients
-    - Search and retrieve data from the database
-    - Provide statistics and insights
-    - Guide users through workflows
-    - Execute actions via tools (with user confirmation)
-
-    Example:
-        User: "Quante fatture ho emesso quest'anno?"
-        Agent: [calls get_invoice_stats tool]
-        Agent: "Hai emesso 42 fatture nel 2025..."
+    Product CLI traffic goes through :class:`AssistantRuntime` (default backend
+    ``langgraph``). This class remains for structured agents and ``chat`` rollback.
     """
 
     def __init__(
@@ -53,23 +49,12 @@ class ChatAgent(BaseAgent[ChatContext]):
         enable_streaming: bool = True,
         debug_config: DebugConfig | None = None,
     ) -> None:
-        """
-        Initialize Chat Agent.
-
-        Args:
-            provider: LLM provider instance
-            tool_registry: Tool registry (uses global if None)
-            enable_tools: Enable tool calling
-            enable_streaming: Enable streaming responses (default: True for better UX)
-            debug_config: Debug configuration for logging controls
-        """
-        # Agent configuration
         config = AgentConfig(
             name="chat_assistant",
             description="General-purpose conversational assistant for OpenFatture",
-            version="1.0.0",
-            temperature=0.7,  # Balanced creativity
-            max_tokens=1500,  # Enough for detailed responses
+            version="1.1.0",
+            temperature=0.7,
+            max_tokens=1500,
             tools_enabled=enable_tools,
             memory_enabled=True,
             rag_enabled=True,
@@ -78,14 +63,12 @@ class ChatAgent(BaseAgent[ChatContext]):
 
         super().__init__(config=config, provider=provider)
 
-        # Tool management
         self.tool_registry = tool_registry or get_tool_registry()
         self.enable_tools = enable_tools
         self.debug_config = debug_config
+        self._graph_backend: Any | None = None
 
-        # Get dynamic logger
         self.logger = get_dynamic_logger(__name__, debug_config)
-
         self.logger.info(
             "chat_agent_initialized",
             provider=provider.provider_name,
@@ -93,85 +76,62 @@ class ChatAgent(BaseAgent[ChatContext]):
             tools_enabled=enable_tools,
             streaming_enabled=enable_streaming,
             chat_debug_enabled=debug_config.enable_chat_debug if debug_config else False,
+            orchestration="graph_assistant_backend",
         )
 
+    def _get_graph_backend(self) -> Any:
+        """Lazy GraphAssistantBackend shared for tool/plain/ReAct turns."""
+        if self._graph_backend is None:
+            from openfatture.ai.runtime.graph_backend import GraphAssistantBackend
+
+            self._graph_backend = GraphAssistantBackend(
+                provider=self.provider,
+                tool_registry=self.tool_registry,
+                enable_tools=self.enable_tools,
+                max_iterations=DEFAULT_TOOL_MAX_ITERATIONS,
+                debug_config=self.debug_config,
+                temperature=self.config.temperature,
+                max_tokens=self.config.max_tokens,
+            )
+        return self._graph_backend
+
     async def validate_input(self, context: ChatContext) -> tuple[bool, str | None]:
-        """
-        Validate chat context before processing.
-
-        Args:
-            context: Chat context
-
-        Returns:
-            Tuple of (is_valid, error_message)
-        """
-        # Basic validation
         if not context.user_input or len(context.user_input.strip()) == 0:
             return False, "Input utente richiesto"
-
         if len(context.user_input) > 5000:
             return False, "Input troppo lungo (max 5000 caratteri)"
-
         return True, None
 
     def _ensure_available_tools(self, context: ChatContext) -> None:
-        """Populate tool names on context when tools are enabled and list is empty."""
         if self.enable_tools and not context.available_tools:
             context.available_tools = self.get_available_tools()
 
     async def execute(self, context: ChatContext, **kwargs: Any) -> AgentResponse:
-        """Execute chat agent, dispatching to native tool calling or ReAct.
-
-        Dispatch logic:
-        - Native tool calling (NativeToolOrchestrator) when the provider
-          supports tools and tools are available.
-        - ReAct (prompt-engineered) when the provider does not support native
-          tool calling but tools are available.
-        - Plain generation otherwise.
-
-        If ``self.config.output_schema`` is set and the provider supports
-        native tools, a forced structured-output call is performed instead.
-        """
+        """Execute one turn: structured schema path or shared graph orchestration."""
         collector = get_metrics_collector()
         self._ensure_available_tools(context)
 
         with MetricsTimer("chat_agent_execute", {"agent": self.config.name}):
             try:
-                use_tools = (
-                    self.enable_tools
-                    and self.provider.supports_tools
-                    and bool(context.available_tools)
-                )
-                use_react = (
-                    self.enable_tools
-                    and not self.provider.supports_tools
-                    and bool(context.available_tools)
-                )
-
                 if self.config.output_schema and self.provider.supports_tools:
                     response = await self._execute_structured(context, **kwargs)
-                elif use_tools:
-                    response = await self._execute_native_tools(context, **kwargs)
-                elif use_react:
-                    response = await self._execute_react(context, **kwargs)
                 else:
-                    response = await super().execute(context, **kwargs)
+                    response = await self._get_graph_backend().run(context)
+                    response.agent_name = self.config.name
+                    response = await self._parse_response(response, context)
 
-                # Record successful execution
                 collector.increment_counter(
                     "chat_agent_executions", tags={"agent": self.config.name, "success": "true"}
                 )
-                if hasattr(response, "usage") and response.usage:
+                if response.usage is not None:
                     record_ai_request(
                         provider=self.provider.provider_name,
                         model=self.provider.model,
                         tokens=response.usage.total_tokens,
-                        duration_ms=0,  # Would need to track timing separately
+                        duration_ms=0,
                         success=True,
                     )
-
                 return response
-
             except Exception as e:
                 collector.increment_counter(
                     "chat_agent_executions", tags={"agent": self.config.name, "success": "false"}
@@ -179,98 +139,16 @@ class ChatAgent(BaseAgent[ChatContext]):
                 collector.record_error("chat_agent_error", str(e), {"agent": self.config.name})
                 raise
 
-    async def _execute_native_tools(self, context: ChatContext, **kwargs: Any) -> AgentResponse:
-        """Run the native tool-calling loop via NativeToolOrchestrator."""
-        logger.info(
-            "using_native_tool_calling",
-            agent=self.config.name,
-            provider=self.provider.provider_name,
-            tools_count=len(context.available_tools),
-        )
-
-        is_valid, error_msg = await self.validate_input(context)
-        if not is_valid:
-            return AgentResponse(
-                content="",
-                status=ResponseStatus.ERROR,
-                agent_name=self.config.name,
-                error=error_msg,
-            )
-
-        messages = await self._build_prompt(context)
-        orchestrator = NativeToolOrchestrator(
-            provider=self.provider,
-            tool_registry=self.tool_registry,
-            max_iterations=5,
-            debug_config=self.debug_config,
-        )
-
-        response = await orchestrator.execute(
-            context=context,
-            messages=messages,
-            system_prompt=self.config.system_prompt,
-            temperature=self.config.temperature,
-            max_tokens=self.config.max_tokens,
-            **kwargs,
-        )
-
-        response.agent_name = self.config.name
-        response.metadata["orchestrator"] = "native_tools"
-        response.metadata["orchestrator_metrics"] = orchestrator.get_metrics()
-        return await self._parse_response(response, context)
-
-    async def _execute_react(self, context: ChatContext, **kwargs: Any) -> AgentResponse:
-        """Run the ReAct loop and wrap the string result in an AgentResponse."""
-        logger.info(
-            "using_react_orchestration",
-            agent=self.config.name,
-            provider=self.provider.provider_name,
-            tools_count=len(context.available_tools),
-        )
-
-        is_valid, error_msg = await self.validate_input(context)
-        if not is_valid:
-            return AgentResponse(
-                content="",
-                status=ResponseStatus.ERROR,
-                agent_name=self.config.name,
-                error=error_msg,
-            )
-
-        orchestrator = ReActOrchestrator(
-            provider=self.provider,
-            tool_registry=self.tool_registry,
-            max_iterations=5,
-            debug_config=self.debug_config,
-        )
-
-        final_answer = await orchestrator.execute(context)
-
-        response = AgentResponse(
-            content=final_answer,
-            status=ResponseStatus.SUCCESS,
-            agent_name=self.config.name,
-            model=self.provider.model,
-            provider=self.provider.provider_name,
-        )
-        response.metadata["orchestrator"] = "react"
-        response.metadata["orchestrator_metrics"] = orchestrator.get_metrics()
-        return await self._parse_response(response, context)
-
     async def _execute_structured(self, context: ChatContext, **kwargs: Any) -> AgentResponse:
-        """Run a forced structured-output call against a tool-capable provider.
-
-        Uses provider-native structured output:
-        - Anthropic: a single forced tool whose ``input_schema`` is the desired
-          schema (``tool_choice={'type': 'tool', 'name': ...}``).
-        - OpenAI: ``response_format={'type': 'json_schema', ...}``.
-
-        The validated payload is placed in ``response.metadata['structured']``.
-        Falls back to post-hoc JSON parsing of ``response.content`` if the
-        provider returns plain text.
-        """
+        """Forced structured-output call (not part of the tool-loop graph)."""
         schema = self.config.output_schema
-        assert schema is not None  # guarded by caller
+        if schema is None:
+            return AgentResponse(
+                content="",
+                status=ResponseStatus.ERROR,
+                agent_name=self.config.name,
+                error="output_schema is required for structured execution",
+            )
 
         is_valid, error_msg = await self.validate_input(context)
         if not is_valid:
@@ -326,14 +204,8 @@ class ChatAgent(BaseAgent[ChatContext]):
 
     @staticmethod
     def _extract_structured_payload(response: AgentResponse) -> dict[str, Any] | None:
-        """Extract the structured payload from a provider response.
-
-        Prefers a forced tool call (Anthropic), then falls back to parsing
-        ``response.content`` as JSON (OpenAI json_schema / post-hoc).
-        """
         if response.tool_calls:
             return response.tool_calls[0].arguments
-
         if response.content:
             try:
                 parsed = json.loads(response.content)
@@ -341,313 +213,22 @@ class ChatAgent(BaseAgent[ChatContext]):
                     return parsed
             except (json.JSONDecodeError, ValueError):
                 return None
-
         return None
 
     async def execute_stream(
         self, context: ChatContext, **kwargs: Any
     ) -> AsyncIterator[StreamEvent]:
-        """
-        Execute chat agent with streaming, using ReAct or native tool calling.
-
-        Override BaseAgent.execute_stream() to add tool calling support:
-        - ReAct orchestration for providers that don't support native function calling
-        - Native tool calling for providers that support it
-
-        Args:
-            context: Chat context
-
-        Yields:
-            StreamEvent: Typed streaming events (CONTENT, TOOL_START, TOOL_RESULT, etc.)
-        """
+        """Stream via the shared graph backend (node-granularity tool events)."""
         self._ensure_available_tools(context)
-        # Check if we need ReAct orchestration
-        needs_react = (
-            self.enable_tools
-            and not self.provider.supports_tools
-            and len(context.available_tools) > 0
-        )
-
-        if needs_react:
-            logger.info(
-                "using_react_orchestration",
-                agent=self.config.name,
-                provider=self.provider.provider_name,
-                tools_count=len(context.available_tools),
-            )
-
-            # Use ReAct orchestrator for tool calling
-            orchestrator = ReActOrchestrator(
-                provider=self.provider,
-                tool_registry=self.tool_registry,
-                max_iterations=5,
-                debug_config=self.debug_config,
-            )
-
-            # Wrap ReAct string chunks in StreamEvent.content()
-            async for react_chunk in orchestrator.stream(context):
-                if isinstance(react_chunk, str):
-                    yield StreamEvent.content(react_chunk)
-                else:
-                    yield react_chunk
-
-        elif (
-            self.enable_tools and self.provider.supports_tools and len(context.available_tools) > 0
-        ):
-            # Use native tool calling for providers that support it
-            logger.info(
-                "using_native_tool_calling",
-                agent=self.config.name,
-                provider=self.provider.provider_name,
-                tools_count=len(context.available_tools),
-            )
-
-            async for event in self._execute_stream_with_tools(context, **kwargs):
-                yield event
-
-        else:
-            # Use standard streaming from BaseAgent
-            # (when tools disabled or no tools available)
-            logger.debug(
-                "using_standard_streaming",
-                agent=self.config.name,
-                provider=self.provider.provider_name,
-                supports_tools=self.provider.supports_tools,
-                tools_enabled=self.enable_tools,
-                available_tools=len(context.available_tools),
-            )
-
-            # Wrap BaseAgent string chunks in StreamEvent.content()
-            parent_stream: AsyncIterator[str | StreamEvent] = super().execute_stream(
-                context, **kwargs
-            )
-            async for item in parent_stream:
-                if isinstance(item, str):
-                    yield StreamEvent.content(item)
-                else:
-                    yield item
-
-    async def _execute_stream_with_tools(
-        self,
-        context: ChatContext,
-        **kwargs: Any,
-    ) -> AsyncIterator[StreamEvent]:
-        """
-        Execute with native tool calling support using streaming.
-
-        Accumulates streaming response, detects tool calls, executes them,
-        then continues with follow-up streaming for better UX.
-
-        Args:
-            context: Chat context
-
-        Yields:
-            StreamEvent: Typed events (CONTENT, TOOL_START, TOOL_PROGRESS, TOOL_RESULT, TOOL_ERROR)
-        """
-        # Get tools schema for the provider
-        tools_schema = self.get_tools_schema()
-
-        # Build prompt
-        messages = await self._build_prompt(context)
-
-        logger.info(
-            "streaming_with_tools_started",
-            agent=self.config.name,
-            tools_count=len(tools_schema),
-        )
-
-        # Use stream_structured for real-time content and tool call streaming
-        accumulated_content = ""
-        pending_tool_calls = []
-
-        try:
-            stream_kwargs = dict(kwargs)
-            stream_kwargs.setdefault("tools", tools_schema)
-
-            async for chunk in self.provider.stream_structured(
-                messages=messages,
-                temperature=self.config.temperature,
-                max_tokens=self.config.max_tokens,
-                **stream_kwargs,
-            ):
-                if chunk.content:
-                    # Yield content chunk as StreamEvent
-                    accumulated_content += chunk.content
-                    yield StreamEvent.content(chunk.content)
-
-                elif chunk.tool_call:
-                    # Accumulate tool calls
-                    pending_tool_calls.append(chunk.tool_call)
-
-                elif chunk.is_final:
-                    # End of response - execute any pending tool calls
-                    if pending_tool_calls:
-                        logger.info(
-                            "tool_calls_detected_in_stream",
-                            agent=self.config.name,
-                            tool_count=len(pending_tool_calls),
-                            content_length=len(accumulated_content),
-                            tool_names=[tc.name for tc in pending_tool_calls],
-                        )
-
-                        # Execute tools with timing
-                        import time
-
-                        start_time = time.time()
-
-                        tool_results = await self._handle_tool_calls(
-                            [
-                                {
-                                    "function": {"name": tc.name, "arguments": tc.arguments},
-                                    "id": tc.id,
-                                }
-                                for tc in pending_tool_calls
-                            ],
-                            context,
-                        )
-
-                        execution_time = time.time() - start_time
-
-                        # Emit tool execution events
-                        successful_count = 0
-                        failed_count = 0
-
-                        for tool_call in pending_tool_calls:
-                            tool_name = tool_call.name
-                            # tool_call.arguments is already a dict[str, Any]
-                            tool_args_dict = tool_call.arguments
-
-                            # Emit TOOL_START event
-                            yield StreamEvent.tool_start(
-                                tool_name=tool_name,
-                                parameters=tool_args_dict,
-                            )
-
-                            # Find corresponding result
-                            result = next(
-                                (r for r in tool_results if r.get("tool_name") == tool_name), None
-                            )
-
-                            if result and result.get("result"):
-                                tool_data = result["result"]
-                                if tool_data.get("success"):
-                                    successful_count += 1
-                                    # Emit TOOL_RESULT event
-                                    yield StreamEvent.tool_result(
-                                        tool_name=tool_name,
-                                        result=tool_data.get("data", ""),
-                                        duration_ms=execution_time * 1000,
-                                    )
-                                else:
-                                    failed_count += 1
-                                    error_msg = tool_data.get("error", "Errore sconosciuto")
-                                    # Emit TOOL_ERROR event
-                                    yield StreamEvent.tool_error(
-                                        tool_name=tool_name,
-                                        error=error_msg,
-                                    )
-                            else:
-                                failed_count += 1
-                                # Emit TOOL_ERROR event
-                                yield StreamEvent.tool_error(
-                                    tool_name=tool_name,
-                                    error="Risultato non disponibile",
-                                )
-
-                        # Emit summary metrics event
-                        if successful_count > 0 or failed_count > 0:
-                            yield StreamEvent.metrics(
-                                successful_tools=successful_count,
-                                failed_tools=failed_count,
-                                execution_time_ms=execution_time * 1000,
-                            )
-
-                        # Follow-up conversation with tool results
-                        followup_messages = messages.copy()
-
-                        # Add assistant message with tool calls
-                        from openfatture.ai.domain.message import Message, Role
-
-                        # Format tool calls for the assistant message
-                        tool_calls_for_message = [
-                            {
-                                "id": tc.id,
-                                "type": "function",
-                                "function": {
-                                    "name": tc.name,
-                                    "arguments": tc.arguments,
-                                },
-                            }
-                            for tc in pending_tool_calls
-                        ]
-
-                        followup_messages.append(
-                            Message(
-                                role=Role.ASSISTANT,
-                                content=accumulated_content,
-                                tool_calls=tool_calls_for_message,
-                            )
-                        )
-
-                        # Add tool results as separate messages
-                        for result in tool_results:
-                            tool_data = result.get("result", {})
-                            followup_messages.append(
-                                Message(
-                                    role=Role.TOOL,
-                                    content=str(tool_data.get("data", "")),
-                                    tool_call_id=result.get("tool_call_id"),
-                                )
-                            )
-
-                        # Stream follow-up response
-                        # (Status message now handled by consumer via METRICS event)
-
-                        followup_content = ""
-                        async for followup_chunk in self.provider.stream(
-                            messages=followup_messages,
-                            temperature=self.config.temperature,
-                            max_tokens=self.config.max_tokens,
-                        ):
-                            followup_content += followup_chunk
-                            yield StreamEvent.content(followup_chunk)
-
-                        logger.info(
-                            "streaming_with_tools_completed",
-                            agent=self.config.name,
-                            initial_content_length=len(accumulated_content),
-                            followup_content_length=len(followup_content),
-                            tools_executed=len(tool_results),
-                            successful_tools=successful_count,
-                            failed_tools=failed_count,
-                            execution_time=execution_time,
-                        )
-                    else:
-                        # No tool calls - just log completion
-                        logger.info(
-                            "streaming_with_tools_completed_no_tools",
-                            agent=self.config.name,
-                            content_length=len(accumulated_content),
-                        )
-
-        except Exception as e:
-            logger.error(
-                "streaming_with_tools_failed",
-                agent=self.config.name,
-                error=str(e),
-                accumulated_content_length=len(accumulated_content),
-            )
-            # Emit error as StreamEvent
-            yield StreamEvent.content(f"\n\nErrore durante l'esecuzione: {str(e)}")
+        async for event in self._get_graph_backend().stream(context):
+            yield event
 
     async def _build_prompt(self, context: ChatContext) -> list[Message]:
-        """Build prompt messages (shared helper with LangGraph product backend)."""
         from openfatture.ai.runtime.prompt import build_chat_messages
 
         return build_chat_messages(context, enable_tools=self.enable_tools)
 
     def _build_system_prompt(self, context: ChatContext) -> str:
-        """Build system prompt (shared helper with LangGraph product backend)."""
         from openfatture.ai.runtime.prompt import build_chat_system_prompt
 
         return build_chat_system_prompt(context, enable_tools=self.enable_tools)
@@ -657,145 +238,22 @@ class ChatAgent(BaseAgent[ChatContext]):
         response: AgentResponse,
         context: ChatContext,
     ) -> AgentResponse:
-        """
-        Parse and process LLM response.
-
-        Handles tool calls if present.
-
-        Args:
-            response: Raw LLM response
-            context: Chat context
-
-        Returns:
-            Processed AgentResponse
-        """
-        # Check for tool calls in response
-        # This is provider-specific - simplified here
-        # In production, handle OpenAI/Anthropic tool calling formats
-
-        # Add context info to metadata
         response.metadata["session_id"] = context.session_id
         response.metadata["message_count"] = len(context.conversation_history.messages)
         response.metadata["tools_available"] = len(context.available_tools)
-
         return response
 
-    async def _handle_tool_calls(
-        self,
-        tool_calls: list[dict[str, Any]],
-        context: ChatContext,
-    ) -> list[dict[str, Any]]:
-        """
-        Execute tool calls from LLM.
-
-        Args:
-            tool_calls: List of tool call dictionaries
-            context: Chat context
-
-        Returns:
-            List of tool results
-        """
-        results = []
-
-        for tool_call in tool_calls:
-            tool_name = tool_call.get("function", {}).get("name")
-            try:
-                # Extract tool info
-                parameters = tool_call.get("function", {}).get("arguments", {})
-
-                if not tool_name:
-                    continue
-
-                logger.info(
-                    "executing_tool",
-                    tool_name=tool_name,
-                    parameters=parameters,
-                )
-
-                # Execute tool
-                result = await self.tool_registry.execute_tool(
-                    tool_name=tool_name,
-                    parameters=parameters,
-                    confirm=False,  # In interactive UI, we'll handle confirmation
-                )
-
-                results.append(
-                    {
-                        "tool_call_id": tool_call.get("id"),
-                        "tool_name": tool_name,
-                        "result": result.to_dict(),
-                    }
-                )
-
-                # Add to context
-                context.tool_results.append(
-                    {
-                        "tool": tool_name,
-                        "parameters": parameters,
-                        "result": result.data,
-                        "success": result.success,
-                    }
-                )
-
-            except Exception as e:
-                logger.error(
-                    "tool_execution_failed",
-                    tool_name=tool_name or "unknown",
-                    error=str(e),
-                )
-                results.append(
-                    {
-                        "tool_call_id": tool_call.get("id"),
-                        "tool_name": tool_name or "unknown",
-                        "error": str(e),
-                    }
-                )
-
-        return results
-
     def get_available_tools(self, category: str | None = None) -> list[str]:
-        """
-        Get list of available tool names.
-
-        Args:
-            category: Filter by category
-
-        Returns:
-            List of tool names
-        """
         tools = self.tool_registry.list_tools(category=category)
         return [t.name for t in tools]
 
     def get_tools_schema(self, provider_format: str = "openai") -> list[dict[str, Any]]:
-        """
-        Get tools schema for function calling.
-
-        Args:
-            provider_format: Format ("openai" or "anthropic")
-
-        Returns:
-            List of tool schemas
-        """
         if provider_format == "anthropic":
             return self.tool_registry.get_anthropic_tools()
-        else:
-            return self.tool_registry.get_openai_functions()
+        return self.tool_registry.get_openai_functions()
 
     async def generate_title(self, context: ChatContext) -> str:
-        """
-        Generate a title for the conversation based on first message.
-
-        Args:
-            context: Chat context
-
-        Returns:
-            Generated title
-        """
-        # Simple implementation - use first user message
-        # In production, could use LLM to generate a summary title
-
         first_message = context.user_input[:50]
         if len(context.user_input) > 50:
             first_message += "..."
-
         return first_message

--- a/openfatture/ai/runtime/service.py
+++ b/openfatture/ai/runtime/service.py
@@ -5,8 +5,8 @@ business operations. Interactive sessions optionally persist via the
 file-backed session store.
 
 Backends (settings ``assistant_backend``):
-- ``chat`` → ChatAgent tool loop (default)
-- ``langgraph`` → GraphAssistantBackend (opt-in product path)
+- ``langgraph`` → GraphAssistantBackend (default product path)
+- ``chat`` → ChatAgent rollback (delegates tool loop to the same graph backend)
 """
 
 from __future__ import annotations
@@ -14,7 +14,6 @@ from __future__ import annotations
 from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Any
 
-from openfatture.ai.agents.chat_agent import ChatAgent
 from openfatture.ai.domain.context import ChatContext
 from openfatture.ai.domain.message import ConversationHistory, Message, Role
 from openfatture.ai.domain.response import AgentResponse
@@ -33,6 +32,7 @@ from openfatture.platform.extras import require_extra
 from openfatture.platform.logging import get_logger
 
 if TYPE_CHECKING:
+    from openfatture.ai.agents.chat_agent import ChatAgent
     from openfatture.ai.runtime.graph_backend import GraphAssistantBackend
     from openfatture.ai.session.models import ChatSession
     from openfatture.ai.session.store import SessionStore
@@ -57,13 +57,13 @@ def _resolve_backend_name(
     backend: AssistantBackendName | None, settings: Settings
 ) -> AssistantBackendName:
     """Map ctor override or settings to a validated backend name."""
-    if backend == ASSISTANT_BACKEND_LANGGRAPH:
+    if backend is not None:
+        if backend == ASSISTANT_BACKEND_CHAT:
+            return ASSISTANT_BACKEND_CHAT
         return ASSISTANT_BACKEND_LANGGRAPH
-    if backend == ASSISTANT_BACKEND_CHAT:
+    if settings.assistant_backend == ASSISTANT_BACKEND_CHAT:
         return ASSISTANT_BACKEND_CHAT
-    if settings.assistant_backend == ASSISTANT_BACKEND_LANGGRAPH:
-        return ASSISTANT_BACKEND_LANGGRAPH
-    return ASSISTANT_BACKEND_CHAT
+    return ASSISTANT_BACKEND_LANGGRAPH
 
 
 class AssistantRuntime:
@@ -93,15 +93,20 @@ class AssistantRuntime:
         self._backend_name = _resolve_backend_name(backend, self.settings)
         self._backend_id = resolve_backend_id(self._backend_name)
 
-        self._agent = ChatAgent(
-            provider=self._provider,
-            tool_registry=self._tool_registry,
-            enable_streaming=enable_streaming,
-            enable_tools=enable_tools,
-            debug_config=self.debug_config,
-        )
+        self._agent: ChatAgent | None = None
         self._graph_backend: GraphAssistantBackend | None = None
-        if self._backend_name == ASSISTANT_BACKEND_LANGGRAPH:
+
+        if self._backend_name == ASSISTANT_BACKEND_CHAT:
+            from openfatture.ai.agents.chat_agent import ChatAgent
+
+            self._agent = ChatAgent(
+                provider=self._provider,
+                tool_registry=self._tool_registry,
+                enable_streaming=enable_streaming,
+                enable_tools=enable_tools,
+                debug_config=self.debug_config,
+            )
+        else:
             from openfatture.ai.runtime.graph_backend import GraphAssistantBackend
 
             self._graph_backend = GraphAssistantBackend(
@@ -164,7 +169,6 @@ class AssistantRuntime:
         else:
             conv = ConversationHistory()
         context = ChatContext(user_input=user_input, conversation_history=conv)
-        # Populate tools for both backends so native/ReAct paths actually run.
         if self.enable_tools and not context.available_tools:
             context.available_tools = [t.name for t in self._tool_registry.list_tools()]
         return context
@@ -200,8 +204,10 @@ class AssistantRuntime:
         context = self._context(user_input, history)
         if self._graph_backend is not None:
             response = await self._graph_backend.run(context)
-        else:
+        elif self._agent is not None:
             response = await self._agent.execute(context)
+        else:
+            raise RuntimeError("AssistantRuntime has no configured backend")
         self._persist_turn(user_input, response.content or "", response)
         return response
 
@@ -216,8 +222,10 @@ class AssistantRuntime:
         answer_parts: list[str] = []
         if self._graph_backend is not None:
             stream_iter: AsyncIterator[StreamEvent] = self._graph_backend.stream(context)
-        else:
+        elif self._agent is not None:
             stream_iter = self._agent.execute_stream(context)
+        else:
+            raise RuntimeError("AssistantRuntime has no configured backend")
         async for item in stream_iter:
             if item.is_content():
                 answer_parts.append(item.get_text())

--- a/openfatture/platform/config.py
+++ b/openfatture/platform/config.py
@@ -256,12 +256,11 @@ class Settings(BaseSettings):
 
     # AI Chat Assistant
     assistant_backend: Literal["chat", "langgraph"] = Field(
-        default="chat",
+        default="langgraph",
         description=(
             "Product assistant orchestration backend: "
-            "'chat' (ChatAgent / NativeToolOrchestrator) or "
-            "'langgraph' (StateGraph model↔tools loop). Default remains chat until "
-            "parity gates flip it."
+            "'langgraph' (default StateGraph model↔tools loop) or "
+            "'chat' (ChatAgent rollback; tool loop still uses GraphAssistantBackend)."
         ),
     )
     ai_chat_enabled: bool = Field(

--- a/tests/ai/test_assistant_backend_parity.py
+++ b/tests/ai/test_assistant_backend_parity.py
@@ -82,7 +82,7 @@ def _runtime(backend: str, provider: MagicMock, registry: MagicMock) -> Any:
 
 
 @pytest.mark.asyncio
-async def test_default_backend_is_chat() -> None:
+async def test_explicit_chat_backend_id() -> None:
     provider, registry = _provider_and_registry()
     runtime = _runtime("chat", provider, registry)
     assert runtime.backend == BACKEND_CHAT
@@ -95,6 +95,25 @@ async def test_langgraph_backend_id() -> None:
     runtime = _runtime("langgraph", provider, registry)
     assert runtime.backend == BACKEND_LANGGRAPH
     assert runtime.assistant_backend == "langgraph"
+
+
+@pytest.mark.asyncio
+async def test_settings_default_backend_is_langgraph() -> None:
+    """Product default (no ctor override) is langgraph_tool_loop."""
+    provider, registry = _provider_and_registry()
+    with (
+        patch("openfatture.platform.extras.require_extra"),
+        patch("openfatture.ai.providers.factory.create_provider", return_value=provider),
+        patch("openfatture.ai.tools.registry.get_tool_registry", return_value=registry),
+        patch("openfatture.ai.runtime.service.get_tool_registry", return_value=registry),
+    ):
+        from openfatture.ai.runtime import create_assistant_runtime
+        from openfatture.platform.config import Settings
+
+        settings = Settings(assistant_backend="langgraph")
+        runtime = create_assistant_runtime(provider=provider, settings=settings)
+        assert runtime.backend == BACKEND_LANGGRAPH
+        assert runtime.assistant_backend == "langgraph"
 
 
 @pytest.mark.asyncio

--- a/tests/ai/test_assistant_runtime.py
+++ b/tests/ai/test_assistant_runtime.py
@@ -9,9 +9,44 @@ from openfatture.ai.domain.response import AgentResponse, ResponseStatus, UsageM
 
 
 @pytest.mark.asyncio
-async def test_runtime_run_delegates_to_chat_agent() -> None:
+async def test_runtime_run_uses_langgraph_by_default() -> None:
     mock_response = AgentResponse(
         content="ok",
+        status=ResponseStatus.SUCCESS,
+        agent_name="chat",
+        usage=UsageMetrics(total_tokens=1, estimated_cost_usd=0.0),
+    )
+    empty_registry = MagicMock(list_tools=MagicMock(return_value=[]))
+    empty_registry.get_openai_functions.return_value = []
+    with (
+        patch("openfatture.platform.extras.require_extra"),
+        patch("openfatture.ai.providers.factory.create_provider") as mock_prov,
+        patch("openfatture.ai.tools.registry.get_tool_registry", return_value=empty_registry),
+        patch("openfatture.ai.runtime.service.get_tool_registry", return_value=empty_registry),
+        patch("openfatture.ai.runtime.graph_backend.GraphAssistantBackend") as mock_graph_cls,
+    ):
+        mock_prov.return_value = MagicMock(provider_name="openai", model="gpt", supports_tools=True)
+        graph_backend = MagicMock()
+        graph_backend.run = AsyncMock(return_value=mock_response)
+        mock_graph_cls.return_value = graph_backend
+
+        from openfatture.ai.runtime import create_assistant_runtime
+        from openfatture.platform.config import Settings
+
+        runtime = create_assistant_runtime(
+            settings=Settings(assistant_backend="langgraph"),
+        )
+        result = await runtime.run("lista fatture")
+        assert result.content == "ok"
+        graph_backend.run.assert_awaited_once()
+        assert runtime.session_id is None
+        assert runtime.backend == "langgraph_tool_loop"
+
+
+@pytest.mark.asyncio
+async def test_runtime_chat_backend_uses_chat_agent() -> None:
+    mock_response = AgentResponse(
+        content="ok-chat",
         status=ResponseStatus.SUCCESS,
         agent_name="chat",
         usage=UsageMetrics(total_tokens=1, estimated_cost_usd=0.0),
@@ -21,7 +56,8 @@ async def test_runtime_run_delegates_to_chat_agent() -> None:
         patch("openfatture.platform.extras.require_extra"),
         patch("openfatture.ai.providers.factory.create_provider") as mock_prov,
         patch("openfatture.ai.tools.registry.get_tool_registry", return_value=empty_registry),
-        patch("openfatture.ai.runtime.service.ChatAgent") as mock_agent_cls,
+        patch("openfatture.ai.runtime.service.get_tool_registry", return_value=empty_registry),
+        patch("openfatture.ai.agents.chat_agent.ChatAgent") as mock_agent_cls,
     ):
         mock_prov.return_value = MagicMock(provider_name="openai", model="gpt", supports_tools=True)
         agent = MagicMock()
@@ -30,29 +66,30 @@ async def test_runtime_run_delegates_to_chat_agent() -> None:
 
         from openfatture.ai.runtime import create_assistant_runtime
 
-        runtime = create_assistant_runtime()
+        runtime = create_assistant_runtime(backend="chat")
         result = await runtime.run("lista fatture")
-        assert result.content == "ok"
+        assert result.content == "ok-chat"
         agent.execute.assert_awaited_once()
-        assert runtime.session_id is None
         assert runtime.backend == "chat_agent_tool_loop"
 
 
 def test_build_assistant_graph_compiles() -> None:
     empty_registry = MagicMock(list_tools=MagicMock(return_value=[]))
+    empty_registry.get_openai_functions.return_value = []
     with (
         patch("openfatture.platform.extras.require_extra"),
         patch("openfatture.ai.providers.factory.create_provider") as mock_prov,
         patch("openfatture.ai.tools.registry.get_tool_registry", return_value=empty_registry),
-        patch("openfatture.ai.runtime.service.ChatAgent"),
+        patch("openfatture.ai.runtime.service.get_tool_registry", return_value=empty_registry),
     ):
         mock_prov.return_value = MagicMock(
             provider_name="openai", model="gpt", supports_tools=False
         )
         from openfatture.ai.runtime import create_assistant_runtime
         from openfatture.ai.runtime.graph import build_assistant_graph
+        from openfatture.platform.config import Settings
 
-        runtime = create_assistant_runtime()
+        runtime = create_assistant_runtime(settings=Settings(assistant_backend="langgraph"))
         graph = build_assistant_graph(runtime)
         assert graph is not None
         assert hasattr(graph, "ainvoke")
@@ -67,11 +104,13 @@ async def test_runtime_persist_session_saves_and_reloads(tmp_path: Path) -> None
         usage=UsageMetrics(total_tokens=2, estimated_cost_usd=0.0),
     )
     empty_registry = MagicMock(list_tools=MagicMock(return_value=[]))
+    empty_registry.get_openai_functions.return_value = []
     with (
         patch("openfatture.platform.extras.require_extra"),
         patch("openfatture.ai.providers.factory.create_provider") as mock_prov,
         patch("openfatture.ai.tools.registry.get_tool_registry", return_value=empty_registry),
-        patch("openfatture.ai.runtime.service.ChatAgent") as mock_agent_cls,
+        patch("openfatture.ai.runtime.service.get_tool_registry", return_value=empty_registry),
+        patch("openfatture.ai.runtime.graph_backend.GraphAssistantBackend") as mock_graph_cls,
         patch("openfatture.ai.session.get_session_store") as mock_store_factory,
     ):
         from openfatture.ai.session.file_store import FileSessionStore
@@ -79,13 +118,17 @@ async def test_runtime_persist_session_saves_and_reloads(tmp_path: Path) -> None
         store = FileSessionStore(sessions_dir=tmp_path)
         mock_store_factory.return_value = store
         mock_prov.return_value = MagicMock(provider_name="openai", model="gpt")
-        agent = MagicMock()
-        agent.execute = AsyncMock(return_value=mock_response)
-        mock_agent_cls.return_value = agent
+        graph_backend = MagicMock()
+        graph_backend.run = AsyncMock(return_value=mock_response)
+        mock_graph_cls.return_value = graph_backend
 
         from openfatture.ai.runtime import create_assistant_runtime
+        from openfatture.platform.config import Settings
 
-        runtime = create_assistant_runtime(persist_session=True)
+        runtime = create_assistant_runtime(
+            persist_session=True,
+            settings=Settings(assistant_backend="langgraph"),
+        )
         assert runtime.session_id is not None
         sid = runtime.session_id
         await runtime.run("hi")

--- a/tests/ai/test_native_tool_calling.py
+++ b/tests/ai/test_native_tool_calling.py
@@ -277,8 +277,8 @@ async def test_native_orchestrator_anthropic_tool_choice(mock_tool_registry):
 
 
 @pytest.mark.asyncio
-async def test_chat_agent_dispatches_to_native(mock_tool_registry):
-    """ChatAgent.execute routes to native orchestrator when supports_tools=True."""
+async def test_chat_agent_dispatches_to_graph_native_tools(mock_tool_registry):
+    """ChatAgent.execute uses GraphAssistantBackend tool loop when supports_tools=True."""
     provider = MagicMock()
     provider.provider_name = "openai"
     provider.model = "gpt-4o"
@@ -300,18 +300,18 @@ async def test_chat_agent_dispatches_to_native(mock_tool_registry):
     response = await agent.execute(context)
 
     assert "42 fatture" in response.content
-    assert response.metadata["orchestrator"] == "native_tools"
+    assert response.metadata["orchestrator"] == "langgraph_tool_loop"
     assert mock_tool_registry.execute_tool.call_count == 1
 
 
 # ---------------------------------------------------------------------------
-# (d) ChatAgent dispatch -> ReAct when supports_tools=False
+# (d) ChatAgent dispatch -> ReAct via graph when supports_tools=False
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_chat_agent_dispatches_to_react(mock_tool_registry):
-    """ChatAgent.execute falls back to ReAct when supports_tools=False."""
+async def test_chat_agent_dispatches_to_graph_react(mock_tool_registry):
+    """ChatAgent.execute uses graph ReAct path when supports_tools=False."""
     provider = MagicMock()
     provider.provider_name = "ollama"
     provider.model = "qwen3:8b"
@@ -322,7 +322,7 @@ async def test_chat_agent_dispatches_to_react(mock_tool_registry):
     context = ChatContext(user_input="Quante fatture?", enable_tools=True)
     context.available_tools = ["get_invoice_count"]
 
-    with patch("openfatture.ai.agents.chat_agent.ReActOrchestrator") as mock_react_cls:
+    with patch("openfatture.ai.orchestration.react.ReActOrchestrator") as mock_react_cls:
         instance = mock_react_cls.return_value
         instance.execute = AsyncMock(return_value="Risposta ReAct con 42 fatture.")
         instance.get_metrics = MagicMock(return_value={"total_executions": 1})
@@ -330,8 +330,7 @@ async def test_chat_agent_dispatches_to_react(mock_tool_registry):
         response = await agent.execute(context)
 
     assert "Risposta ReAct" in response.content
-    assert response.metadata["orchestrator"] == "react"
-    # Native provider.generate must NOT have been used for tool dispatch
+    assert response.metadata["orchestrator"] == "langgraph_react"
     mock_react_cls.assert_called_once()
 
 

--- a/tests/ai/test_streaming.py
+++ b/tests/ai/test_streaming.py
@@ -672,51 +672,48 @@ class TestStreamingToolCalls:
         assert chunks[1].tool_call.arguments == {}  # Should default to empty dict
         assert chunks[2].is_final is True
 
-    async def test_chat_agent_message_construction_with_tool_calls(self, mock_openai_provider):
-        """Test that ChatAgent properly constructs messages with tool_calls for follow-up."""
-        from unittest.mock import AsyncMock
+    async def test_chat_agent_stream_uses_graph_tool_events(self):
+        """ChatAgent.execute_stream emits tool lifecycle via GraphAssistantBackend."""
+        from unittest.mock import AsyncMock, MagicMock
 
-        from openfatture.ai.domain.response import StreamChunk, ToolCall
-        from openfatture.ai.tools import get_tool_registry
+        from openfatture.ai.domain.response import AgentResponse, ResponseStatus, ToolCall
+        from openfatture.ai.streaming.events import StreamEventType
+        from openfatture.ai.tools.models import ToolResult
 
-        class MockToolResult:
-            def __init__(self, data):
-                self.data = data
-                self.success = True
+        tool_registry = MagicMock()
+        tool = MagicMock()
+        tool.name = "get_client_stats"
+        tool_registry.list_tools.return_value = [tool]
+        tool_registry.get_openai_functions.return_value = []
+        tool_registry.execute_tool = AsyncMock(
+            return_value=ToolResult(
+                success=True,
+                data={"total_clients": 3},
+                error=None,
+                tool_name="get_client_stats",
+            )
+        )
 
-            def to_dict(self):
-                return {"success": self.success, "data": self.data}
-
-        # Mock tool registry
-        tool_registry = get_tool_registry()
-        tool_registry.get_tool = AsyncMock(return_value=AsyncMock())
-        tool_registry.execute_tool = AsyncMock(return_value=MockToolResult({"total_clients": 3}))
-
-        initial_chunks = [
-            StreamChunk(content="I'll check your clients"),
-            StreamChunk(
-                content="",
-                tool_call=ToolCall(id="call_123", name="get_client_stats", arguments={}),
-            ),
-            StreamChunk(content="", is_final=True, finish_reason="tool_calls"),
-        ]
-
-        async def fake_stream_structured(messages, **kwargs):
-            for chunk in initial_chunks:
-                yield chunk
-
-        followup_calls = []
-
-        async def fake_followup_stream(messages, **kwargs):
-            followup_calls.append({"messages": messages, "kwargs": kwargs})
-            for part in ["You have 3 clients", ""]:
-                yield part
-
-        mock_openai_provider.stream_structured = fake_stream_structured
-        mock_openai_provider.stream = fake_followup_stream
+        provider = MagicMock()
+        provider.supports_tools = True
+        provider.provider_name = "openai"
+        provider.model = "gpt-test"
+        provider.generate = AsyncMock(
+            side_effect=[
+                AgentResponse(
+                    content="",
+                    status=ResponseStatus.SUCCESS,
+                    tool_calls=[ToolCall(id="call_123", name="get_client_stats", arguments={})],
+                ),
+                AgentResponse(
+                    content="You have 3 clients",
+                    status=ResponseStatus.SUCCESS,
+                ),
+            ]
+        )
 
         agent = ChatAgent(
-            provider=mock_openai_provider,
+            provider=provider,
             tool_registry=tool_registry,
             enable_tools=True,
             enable_streaming=True,
@@ -725,51 +722,17 @@ class TestStreamingToolCalls:
         context = ChatContext(user_input="How many clients do I have?")
         context.available_tools = ["get_client_stats"]
 
-        # Collect all events (now StreamEvent objects)
-        events = []
-        async for event in agent.execute_stream(context):
-            events.append(event)
+        events = [event async for event in agent.execute_stream(context)]
+        types = [e.type for e in events]
 
-        # Extract text from StreamEvent objects
-        text_parts = [e.get_text() for e in events if hasattr(e, "get_text")]
-        _full_text = " ".join(text_parts)
-
-        # Verify that tool calls were detected and executed
-        # Note: Text might be in progress/status events, not just content
-        assert len(events) > 0  # Should have some events
-
-        # Verify that the follow-up stream was called
-        assert len(followup_calls) == 1
-
-        followup_messages = followup_calls[0]["messages"]
-
-        # Verify message structure
-        assert len(followup_messages) >= 3  # Original + assistant + tool
-
-        # Find the assistant message
-        assistant_msg = None
-        tool_msg = None
-        for msg in followup_messages:
-            if msg.role == Role.ASSISTANT:
-                assistant_msg = msg
-            elif msg.role == Role.TOOL:
-                tool_msg = msg
-
-        assert assistant_msg is not None, "Assistant message should be present"
-        assert tool_msg is not None, "Tool message should be present"
-
-        # Verify assistant message has tool_calls
-        assert assistant_msg.tool_calls is not None, "Assistant message should have tool_calls"
-        assert len(assistant_msg.tool_calls) == 1, "Should have one tool call"
-
-        tool_call = assistant_msg.tool_calls[0]
-        assert tool_call["id"] == "call_123"
-        assert tool_call["type"] == "function"
-        assert tool_call["function"]["name"] == "get_client_stats"
-        assert tool_call["function"]["arguments"] == {}
-
-        # Verify tool message has correct tool_call_id
-        assert tool_msg.tool_call_id == "call_123"
+        assert StreamEventType.TOOL_START in types
+        assert StreamEventType.TOOL_RESULT in types
+        assert StreamEventType.CONTENT in types
+        assert types.index(StreamEventType.TOOL_START) < types.index(StreamEventType.TOOL_RESULT)
+        assert any(
+            e.type == StreamEventType.CONTENT and "3 clients" in e.get_text() for e in events
+        )
+        tool_registry.execute_tool.assert_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/ai/test_tool_loop_parity.py
+++ b/tests/ai/test_tool_loop_parity.py
@@ -73,25 +73,26 @@ async def test_graph_tool_round_trip_matches_shape() -> None:
 
 
 @pytest.mark.asyncio
-async def test_product_runtime_default_backend_is_chat() -> None:
-    """Default product path still reports chat_agent_tool_loop (B1-β default)."""
+async def test_product_runtime_default_backend_is_langgraph() -> None:
+    """Default product path reports langgraph_tool_loop after default flip."""
+    provider = MagicMock(provider_name="openai", model="gpt", supports_tools=True)
+    provider.generate = AsyncMock(return_value=_final("ok"))
+    registry = MagicMock(list_tools=MagicMock(return_value=[]))
+    registry.get_openai_functions.return_value = []
     with (
         patch("openfatture.platform.extras.require_extra"),
-        patch("openfatture.ai.providers.factory.create_provider") as mock_prov,
-        patch("openfatture.ai.tools.registry.get_tool_registry") as mock_reg,
-        patch("openfatture.ai.runtime.service.ChatAgent") as mock_agent_cls,
+        patch("openfatture.ai.providers.factory.create_provider", return_value=provider),
+        patch("openfatture.ai.tools.registry.get_tool_registry", return_value=registry),
+        patch("openfatture.ai.runtime.service.get_tool_registry", return_value=registry),
     ):
-        mock_prov.return_value = MagicMock(provider_name="openai", model="gpt")
-        mock_reg.return_value = MagicMock(list_tools=MagicMock(return_value=[]))
-        agent = MagicMock()
-        agent.execute = AsyncMock(return_value=_final("ok"))
-        mock_agent_cls.return_value = agent
-
         from openfatture.ai.runtime import create_assistant_runtime
+        from openfatture.platform.config import Settings
 
-        runtime = create_assistant_runtime()
-        assert runtime.backend == "chat_agent_tool_loop"
-        assert runtime.assistant_backend == "chat"
+        runtime = create_assistant_runtime(
+            provider=provider, settings=Settings(assistant_backend="langgraph")
+        )
+        assert runtime.backend == "langgraph_tool_loop"
+        assert runtime.assistant_backend == "langgraph"
         response = await runtime.run("hello")
         assert response.content == "ok"
 


### PR DESCRIPTION
## Summary

Completes plan PR5 + PR6:

1. **Default flip** — `assistant_backend` / `ASSISTANT_BACKEND` default is now **`langgraph`** (`langgraph_tool_loop`).
2. **Slim ChatAgent** — single tool-loop implementation via `GraphAssistantBackend`. ChatAgent keeps structured output + shared prompts; tool/plain/ReAct turns delegate to the graph. Rollback: `ASSISTANT_BACKEND=chat`.

Version **2.1.0**. No new public CLI commands. No `type: ignore` / `cast` / `noqa`.

## Behavior change

| | 2.0.x | 2.1.0 |
|--|-------|-------|
| Default backend | `chat` | **`langgraph`** |
| Tool orchestration | dual (native ChatAgent + graph helper) | **one** (`GraphAssistantBackend`) |
| Rollback | n/a | `ASSISTANT_BACKEND=chat` |

## Test plan

- [x] Parity + runtime + native dispatch + stream graph events
- [x] `ruff` / `mypy` clean on touched AI packages
- [x] `status --json` shows `langgraph` / `langgraph_tool_loop` and version `2.1.0`
- [ ] CI green