### PR TITLE
chore: project config hygiene after 2.1.0

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "1.2.0"
+current_version = "2.1.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 search = "{current_version}"
@@ -9,18 +9,13 @@ ignore_missing_version = false
 tag = true
 sign_tags = false
 tag_name = "v{new_version}"
-tag_message = "Bump version: {current_version} {new_version}"
+tag_message = "Bump version: {current_version} → {new_version}"
 allow_dirty = false
 commit = true
-message = "Bump version: {current_version} {new_version}"
+message = "Bump version: {current_version} → {new_version}"
 commit_args = ""
 
 [[tool.bumpversion.files]]
 filename = "openfatture/__init__.py"
-search = "__version__ = \"{current_version}\""
-replace = "__version__ = \"{new_version}\""
-
-[[tool.bumpversion.files]]
-filename = "openfatture/ai/__init__.py"
 search = "__version__ = \"{current_version}\""
 replace = "__version__ = \"{new_version}\""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Project config hygiene: pytest local runs no longer force coverage (CI still
+  does); `Settings.app_version` tracks package `__version__`; bumpversion
+  pin aligned to 2.1.0; technical debt docs updated for LangGraph default.
+
 ## [2.1.0] - 2026-08-08
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -215,12 +215,12 @@ uv run bump-my-version bump patch --dry-run --verbose
 ```
 
 When you bump a version, the tool automatically:
-1. Updates `__version__` in `openfatture/__init__.py`
-2. Updates `CHANGELOG.md` with new version header
-3. Creates a git commit: `Bump version: X.Y.Z X.Y.Z+1`
-4. Creates a git tag: `vX.Y.Z+1`
+1. Updates `__version__` in `openfatture/__init__.py` (single source of truth;
+   `openfatture.ai` re-exports it; `Settings.app_version` defaults to it)
+2. Creates a git commit and tag (`vX.Y.Z`) per `.bumpversion.toml`
 
-After bumping, push with: `git push --follow-tags`
+Keep `CHANGELOG.md` and release notes under `docs/releases/` updated **before**
+or **with** the bump. After bumping: `git push --follow-tags`.
 
 ### Updating CHANGELOG
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -46,8 +46,18 @@ fix the root cause instead.
    `ai.tools.registry` is already a package)
 4. Onboarding polish continues (readiness in `status`, slash commands in assistant)
 
-See [TECHNICAL_DEBT.md](TECHNICAL_DEBT.md), [releases/v2.0.2.md](releases/v2.0.2.md),
-and [releases/v2.0.1.md](releases/v2.0.1.md).
+See [TECHNICAL_DEBT.md](TECHNICAL_DEBT.md), [releases/v2.1.0.md](releases/v2.1.0.md),
+[releases/v2.0.2.md](releases/v2.0.2.md), and [releases/v2.0.1.md](releases/v2.0.1.md).
+
+## Coverage floors (CI)
+
+| Suite | Floor | Workflow |
+|-------|-------|----------|
+| Full package | 49% | `test.yml` (`--cov-fail-under=49`) |
+| Payment module | 75% | `payment-tests.yml` (measured ~78%) |
+
+Local default pytest runs **without** coverage (faster). Pass `--cov=openfatture`
+(or use CI flags) when you need a report.
 
 ## Explicit non-goals
 

--- a/docs/TECHNICAL_DEBT.md
+++ b/docs/TECHNICAL_DEBT.md
@@ -1,28 +1,28 @@
 # Technical Debt Inventory
 
-Honest inventory of remaining debt **after** the 2.0.0 modernization release
-(hygiene, Ruff-only tooling, extras, package reorg, core/extension boundaries,
-D2 tools, D3 runtime, honesty gates).
+Honest inventory of remaining debt **after** modernization **2.0** and the
+**2.1.0** LangGraph default flip.
 
-**Last updated:** 2026-08-07  
-Related: [CORE_VS_EXTENSIONS.md](CORE_VS_EXTENSIONS.md), [ARCHITECTURE_REDESIGN.md](ARCHITECTURE_REDESIGN.md),
-[releases/v2.0.0.md](releases/v2.0.0.md).
+**Last updated:** 2026-08-08  
+Related: [STATUS.md](STATUS.md), [CORE_VS_EXTENSIONS.md](CORE_VS_EXTENSIONS.md),
+[ARCHITECTURE_REDESIGN.md](ARCHITECTURE_REDESIGN.md),
+[releases/v2.1.0.md](releases/v2.1.0.md), [releases/v2.0.0.md](releases/v2.0.0.md).
 
 ---
 
 ## Verdict
 
-Structural modernization for 2.0.0 is **done**. Remaining debt is mostly
-**product completeness** (Lightning gRPC, oversized modules, experimental
+Structural modernization and AI product backend flip are **done**. Remaining
+debt is **product completeness** (Lightning gRPC, oversized modules, experimental
 workflows), not packaging chaos.
 
 | Area | Debt level | Notes |
 |------|------------|--------|
 | Public CLI surface | Low | Small agentic surface; status/extras clean |
-| Core billing / SDI / payment | Low | Tools → application; billing namespaces re-export use-cases |
+| Core billing / SDI / payment | Low | Tools → application; billing re-exports use-cases |
 | Package layout | Low | Bounded packages; no empty placeholders |
-| AI runtime | Medium | Product = ChatAgent; LangGraph multi-node is tested helper only |
-| Lightning | Medium–High | Fail-closed; simulate_payment gated; real gRPC still missing |
+| AI runtime | Low | Default `langgraph_tool_loop`; single tool-loop; ChatAgent slimmed (structured + rollback) |
+| Lightning | Medium–High | Fail-closed; real LND gRPC still missing |
 | RAG auto-update | Low | Callback required; default auto-update off |
 | Tooling / types | Low | No in-code suppressions; only E501 formatter ignore |
 | Tests | Low | Skips mostly for external services / interactive |
@@ -36,45 +36,39 @@ workflows), not packaging chaos.
 | Repo hygiene + docs | done |
 | Ruff-only tooling | done |
 | Optional extras | done |
-| D0 non-core cut | done |
-| D1 package reorg | done |
-| Core vs extras vs extensions | done (plugins package removed) |
+| D0–D3 (layout, tools, runtime) | done |
 | Honesty gates (Lightning mock, RAG queue) | done |
-| D2 tools → application services | done |
-| D3 single assistant runtime | done |
-| 2.0.0 release notes | done |
+| 2.0.0–2.0.2 releases | done |
+| LangGraph opt-in product backend | done (2.0.x) |
+| LangGraph **default** + ChatAgent slim | done (**2.1.0**) |
 
 ---
 
 ## High priority (real product risk)
 
-### 1. AI product path vs LangGraph helper
-
-- **Product path:** `AssistantRuntime` → `ChatAgent` (native tools / ReAct).
-- **Helper:** `ai.runtime.graph.build_tool_loop_graph` (multi-node model↔tools).
-- **Workflows:** `ai.orchestration.workflows.*` remain internal/experimental.
-- **Remaining:** promote graph to product only with parity tests; fix simulated
-  human approval in experimental workflows or rename nodes honestly.
-
-### 2. Lightning LND real gRPC still missing
+### 1. Lightning LND real gRPC still missing
 
 - **Files:** `openfatture/lightning/infrastructure/lnd_client.py`
-- **Honesty:** Mock is **off by default** (`allow_mock=False` /
-  `lightning_allow_mock=false`). Without stubs, operations raise `LNDClientError`.
-- **Status:** Silent mock **fixed**; full RPC **still open**. Lightning is
-  experimental until real bindings land.
+- **Honesty:** Mock is **off by default** (`lightning_allow_mock=false`).
+- **Status:** Silent mock fixed; full RPC still open. Lightning is
+  **experimental** until real bindings land — or document a harder cut.
+
+### 2. AI product path — resolved for 2.1.0
+
+- **Default:** `AssistantRuntime` → `GraphAssistantBackend` (`langgraph_tool_loop`).
+- **Rollback:** `ASSISTANT_BACKEND=chat` → slim `ChatAgent` (structured output +
+  same graph for tool/plain/ReAct turns).
+- **Workflows:** `ai.orchestration.workflows.*` remain internal/experimental;
+  not on the public CLI.
 
 ### 3. AI tools → application services — done
 
-- All AI tool modules under `openfatture/ai/tools` are thin adapters.
-- Domain use-cases: `billing.application.*`, `payment.application.*`,
-  `sdi.application.*`, `pdf.tool_ops`.
-- **Follow-up:** split large `*_ops.py` modules where complexity grows.
+- Thin adapters under `openfatture/ai/tools`.
+- Follow-up: split large `*_ops.py` / command modules where complexity grows.
 
 ### 4. RAG auto-update queue honesty — resolved
 
-- Requires a real `reindex_callback` (wired by `AutoIndexingService`).
-- Default auto-update remains disabled.
+- Requires a real `reindex_callback`; default auto-update remains disabled.
 
 ---
 
@@ -82,49 +76,42 @@ workflows), not packaging chaos.
 
 ### Oversized modules
 
-- `ai/agents/cash_flow_predictor.py`, `chat_agent.py`
-- `ai/tools/registry.py`
-- `ai/orchestration/workflows/invoice_creation.py`
-- `billing/application/preventivo_ops.py`, `prodotto_ops.py`, `invoice_commands.py`
-- `storage/database/models.py`
+| Module | ~LOC | Note |
+|--------|------|------|
+| `ai/agents/cash_flow_predictor.py` | ~1091 | P1 split candidate |
+| `ai/orchestration/workflows/invoice_creation.py` | ~921 | experimental |
+| `ai/providers/openai.py` | ~855 | provider adapter |
+| `ai/tools/registry/core.py` | ~718 | package already split |
+| `billing/application/invoice_commands.py` | ~714 | P2 |
+| `storage/database/models.py` | ~672 | split by bounded context |
+| `billing/application/preventivo_ops.py` | ~550 | P2 |
 
-### Empty billing packages — resolved as re-exports
-
-- `billing/clienti`, `billing/prodotti`, `billing/fiscale` re-export
-  application modules (no empty placeholders).
+`chat_agent.py` is slimmed (structured + graph delegation). Registry is a package.
 
 ### Experimental workflow human interrupt
 
-- `invoice_creation` / `compliance_check` use **confidence auto-gates** or
-  leave `awaiting_approval` without inventing human decisions. Real CLI
-  interrupt is not on the product path (internal workflows only).
+- Confidence auto-gates or honest `awaiting_approval`; no invented human decisions.
+- Real CLI interrupt is not on the product path.
 
 ### Type-safety / lint
 
 - **Resolved:** zero in-code `noqa` / `type: ignore` / `pragma: no cover`.
-  Ruff global ignore is only `E501` (formatter-owned).
-- Remaining: `mypy` still ignores entire `tests.*`.
+- Ruff global ignore is only `E501` (formatter-owned).
+- `mypy` still ignores entire `tests.*` (optional incremental typing later).
 - Third-party packages without stubs use `ignore_missing_imports` in
   `pyproject.toml` (external, not project debt).
 
 ### Bulkhead / registry TODOs
 
-- `ai/tools/registry.py`: queue length tracking for bulkhead not implemented.
+- Queue length tracking for bulkhead not implemented (observability).
 
 ### ML accuracy drift
 
-- Signal **explicitly unavailable** (`status: not_implemented` in
-  `get_trigger_summary`); does not silent-trigger and does not claim
-  “accuracy is fine”.
-
-### Fuzzy matcher — resolved
-
-- No Mock/MagicMock special-casing in production matcher.
+- Signal explicitly unavailable (`status: not_implemented`); no silent success claim.
 
 ### `async_bridge` nested loops
 
-- Documented nested path: `nest_asyncio` optional, else worker thread.
-  Primary path remains `asyncio.run`.
+- `nest_asyncio` optional, else worker thread; primary path `asyncio.run`.
 
 ---
 
@@ -133,30 +120,18 @@ workflows), not packaging chaos.
 | Item | Why acceptable |
 |------|----------------|
 | `except Exception` in hooks/events/email | Intentional isolation |
-| Retry / rate-limit `sleep` | Normal control flow |
 | External-service test skips | Correct for CI |
-| SQLAlchemy `.is_(True)` / `.is_(False)` | Correct ORM boolean comparisons |
 | Ruff `E501` ignore | Line length owned by `ruff format` |
 | `tests/**` E402 per-file | Fixture/path setup before SUT import |
 | `__init__.py` F401 per-file | Public re-export barrels |
-
----
-
-## Counts (approximate)
-
-| Signal | Count / note |
-|--------|----------------|
-| Explicit `TODO` in code | ~15 (LND, bulkhead, ML drift, …) |
-| `type: ignore` / `noqa` / `pragma: no cover` | **0** |
-| AI tools → application layer only | D2 done |
-| Skipped tests | mostly external/interactive |
+| Global coverage floor ~49% in CI | Baseline; payment suite has higher floor (75%) |
 
 ---
 
 ## Recommended burn-down order
 
-1. Session resume polish and graph test coverage (product UX)
-2. Lightning: real gRPC **or** keep hard experimental posture in docs/CLI
-3. Split oversized ops modules
-4. Honest experimental workflow approval nodes
-5. Optional: mypy on tests; import-linter boundaries
+1. Lightning: real gRPC **or** keep hard experimental posture in docs/CLI
+2. Split oversized modules (`cash_flow_predictor`, invoice commands, models)
+3. Honest experimental workflow approval nodes (if ever productized)
+4. Optional: mypy on selected tests; import-linter boundaries
+5. Optional: Textual TUI (product decision)

--- a/openfatture/ai/__init__.py
+++ b/openfatture/ai/__init__.py
@@ -15,6 +15,9 @@ Architecture:
 
 from typing import Any
 
+# Same version as the distribution package (do not maintain a second number).
+from openfatture import __version__
+
 # Core domain models
 # Configuration
 from openfatture.ai.config import AISettings, get_ai_settings
@@ -29,8 +32,6 @@ from openfatture.ai.domain import (
     ResponseStatus,
     Role,
 )
-
-__version__ = "1.3.1"
 
 
 def __getattr__(name: str) -> Any:

--- a/openfatture/platform/config.py
+++ b/openfatture/platform/config.py
@@ -16,6 +16,13 @@ from pydantic_settings import (
 dirs = PlatformDirs("openfatture", "venerelabs")
 
 
+def _default_app_version() -> str:
+    """Resolve package version without duplicating the string in Settings."""
+    from openfatture import __version__
+
+    return __version__
+
+
 class DebugConfig(BaseSettings):
     """Dynamic debug configuration controls."""
 
@@ -148,7 +155,11 @@ class Settings(BaseSettings):
 
     # Application
     app_name: str = "OpenFatture"
-    app_version: str = "0.1.0"
+    # Single source of truth: openfatture.__version__ (CLI --version / status use the same).
+    app_version: str = Field(
+        default_factory=_default_app_version,
+        description="Package version (mirrors openfatture.__version__; overridable via env)",
+    )
     debug: bool = False
 
     # Database

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,15 +208,17 @@ module = ["pyasn1_modules.*", "pyasn1_modules"]
 ignore_missing_imports = true
 
 # Third-party packages without usable type stubs (not project suppressions).
+# Grouped by product extra / optional stack for readability.
 [[tool.mypy.overrides]]
 module = ["apscheduler.*", "apscheduler"]
 ignore_missing_imports = true
 
+# lightning webhook stack (optional; not a core install dependency)
 [[tool.mypy.overrides]]
 module = ["fastapi", "fastapi.*"]
 ignore_missing_imports = true
 
-# Optional runtime dependency: imported lazily and guarded by ImportError.
+# Optional nested-loop helper (async_bridge); ImportError-guarded at runtime
 [[tool.mypy.overrides]]
 module = ["nest_asyncio"]
 ignore_missing_imports = true
@@ -224,11 +226,11 @@ ignore_missing_imports = true
 [tool.pytest.ini_options]
 minversion = "8.0"
 # Default gate = fast, deterministic functional suite (unit + integration).
-# Heavy/non-deterministic tiers (performance/benchmark/slow wall-clock asserts,
-# e2e and external-service tests) are opt-in via their markers and run in
-# dedicated CI jobs, e.g. `pytest -m performance` or `pytest -m "ollama and e2e"`.
+# Coverage is opt-in locally (`--cov=openfatture`); CI jobs pass explicit --cov flags.
+# Heavy/non-deterministic tiers (performance/benchmark/slow, e2e, ollama) are opt-in
+# via markers and dedicated CI jobs.
 # A CLI `-m` expression overrides the default below (it is appended after addopts).
-addopts = "-ra -q --cov=openfatture --cov-report=term-missing --cov-report=html -m 'not performance and not benchmark and not slow and not e2e and not ollama'"
+addopts = "-ra -q -m 'not performance and not benchmark and not slow and not e2e and not ollama'"
 testpaths = ["tests"]
 pythonpath = ["."]
 markers = [


### PR DESCRIPTION
## Summary

Package A from the config optimization plan — low-risk hygiene, no product behavior change beyond correct version display.

- Docs: `TECHNICAL_DEBT.md` / `STATUS.md` reflect LangGraph default + coverage floors
- Single version source: `__version__` → `Settings.app_version`, `openfatture.ai`
- Local pytest without forced `--cov` (CI still runs coverage + floors)
- bumpversion pin at 2.1.0; CONTRIBUTING updated

## Test plan

- [x] ruff + mypy on touched modules
- [x] Version alignment smoke (`pkg` / `ai` / `settings` == 2.1.0)
- [x] CLI config/status/logging unit tests
- [ ] CI green