### PR TITLE
chore: SSOT for version, backends, and AI credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Project config hygiene: pytest local runs no longer force coverage (CI still
   does); `Settings.app_version` tracks package `__version__`; bumpversion
   pin aligned to 2.1.0; technical debt docs updated for LangGraph default.
+- **SSOT:** assistant backend ids live in `platform.assistant_backends`;
+  package `__version__` is re-exported by subpackages; `AISettings` hydrates
+  credentials from platform `AI_*` (init/docs) with `OPENFATTURE_AI_*`
+  override precedence; coverage `fail_under=49` in pyproject.
 
 ## [2.1.0] - 2026-08-08
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -55,11 +55,17 @@ uv sync --all-extras
 | `CEDENTE_CODICE_FISCALE` | Tax code |
 | `PEC_ADDRESS` | Certified email address |
 | `PEC_PASSWORD` | Certified email credential |
-| `AI_PROVIDER` | Configured assistant provider |
-| `AI_MODEL` | Provider model name |
-| `AI_API_KEY` | Provider credential |
-| `AI_BASE_URL` | Local provider endpoint, such as Ollama |
-| `ASSISTANT_BACKEND` | Product assistant orchestration: `langgraph` (default StateGraph tool loop) or `chat` (rollback) |
+| `AI_PROVIDER` | **Product SSOT** assistant provider (`openai` / `anthropic` / `ollama`) |
+| `AI_MODEL` | **Product SSOT** model name for the selected provider |
+| `AI_API_KEY` | **Product SSOT** provider credential |
+| `AI_BASE_URL` | **Product SSOT** local provider endpoint (Ollama) |
+| `ASSISTANT_BACKEND` | Product assistant orchestration: `langgraph` (default) or `chat` (rollback) |
+
+Product credentials written by `openfatture init` use the `AI_*` names above.
+The provider factory hydrates `AISettings` from those values (see
+`hydrate_ai_settings_from_platform`). Advanced AI-only knobs may use the
+`OPENFATTURE_AI_*` prefix; when both are set, `OPENFATTURE_AI_*` wins for that
+field.
 
 Sensitive values should be provided through the environment or a protected
 local secrets file. Do not commit credentials.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -51,9 +51,9 @@ See [TECHNICAL_DEBT.md](TECHNICAL_DEBT.md), [releases/v2.1.0.md](releases/v2.1.0
 
 ## Coverage floors (CI)
 
-| Suite | Floor | Workflow |
-|-------|-------|----------|
-| Full package | 49% | `test.yml` (`--cov-fail-under=49`) |
+| Suite | Floor | Source of truth |
+|-------|-------|-----------------|
+| Full package | 49% | `[tool.coverage.report] fail_under` in `pyproject.toml` (+ `test.yml`) |
 | Payment module | 75% | `payment-tests.yml` (measured ~78%) |
 
 Local default pytest runs **without** coverage (faster). Pass `--cov=openfatture`

--- a/openfatture/ai/config/settings.py
+++ b/openfatture/ai/config/settings.py
@@ -309,17 +309,88 @@ class AISettings(BaseSettings):
 _settings: AISettings | None = None
 
 
+def _env_has(name: str) -> bool:
+    """True if an environment variable is set (case-insensitive key match)."""
+    import os
+
+    if not name:
+        return False
+    target = name.upper()
+    return any(key.upper() == target for key in os.environ)
+
+
+def hydrate_ai_settings_from_platform(ai: AISettings) -> AISettings:
+    """Apply product SSOT credentials from platform ``Settings`` (AI_* / init / docs).
+
+    Precedence for mapped fields:
+    1. Explicit ``OPENFATTURE_AI_*`` env (AISettings load) — wins when set
+    2. Platform ``Settings`` (``AI_PROVIDER``, ``AI_API_KEY``, ``AI_MODEL``, …)
+    3. AISettings field defaults
+
+    Advanced multi-key knobs (per-provider models, budgets, chroma) stay on
+    ``AISettings`` / ``OPENFATTURE_AI_*`` only.
+    """
+    from openfatture.platform.config import get_settings
+
+    plat = get_settings()
+    updates: dict[str, object] = {}
+
+    if not _env_has("OPENFATTURE_AI_PROVIDER") and plat.ai_provider:
+        provider_candidate = (plat.ai_provider or "").strip().lower()
+        if provider_candidate in ("openai", "anthropic", "ollama"):
+            updates["provider"] = provider_candidate
+
+    provider = str(updates.get("provider") or ai.provider)
+    model_env = {
+        "openai": "OPENFATTURE_AI_OPENAI_MODEL",
+        "anthropic": "OPENFATTURE_AI_ANTHROPIC_MODEL",
+        "ollama": "OPENFATTURE_AI_OLLAMA_MODEL",
+    }.get(provider, "")
+
+    if plat.ai_model and not _env_has(model_env):
+        if provider == "openai":
+            updates["openai_model"] = plat.ai_model
+        elif provider == "anthropic":
+            updates["anthropic_model"] = plat.ai_model
+        elif provider == "ollama":
+            updates["ollama_model"] = plat.ai_model
+
+    if plat.ai_api_key:
+        from pydantic import SecretStr
+
+        secret = SecretStr(plat.ai_api_key)
+        if provider == "openai" and not _env_has("OPENFATTURE_AI_OPENAI_API_KEY"):
+            updates["openai_api_key"] = secret
+        elif provider == "anthropic" and not _env_has("OPENFATTURE_AI_ANTHROPIC_API_KEY"):
+            updates["anthropic_api_key"] = secret
+
+    if plat.ai_base_url and provider == "ollama" and not _env_has("OPENFATTURE_AI_OLLAMA_BASE_URL"):
+        updates["ollama_base_url"] = plat.ai_base_url
+
+    if not _env_has("OPENFATTURE_AI_TEMPERATURE"):
+        updates["temperature"] = plat.ai_temperature
+    if not _env_has("OPENFATTURE_AI_MAX_TOKENS"):
+        updates["max_tokens"] = plat.ai_max_tokens
+    if not _env_has("OPENFATTURE_AI_TOOLS_ENABLED"):
+        updates["tools_enabled"] = plat.ai_tools_enabled
+
+    if not updates:
+        return ai
+    return ai.model_copy(update=updates)
+
+
 def get_ai_settings() -> AISettings:
     """
     Get global AI settings instance (singleton pattern).
 
-    Returns:
-        AISettings instance
+    Product credentials are hydrated from platform ``Settings`` (see
+    :func:`hydrate_ai_settings_from_platform`) so ``init`` / ``AI_*`` env vars
+    and the provider factory share one source of truth.
     """
     global _settings
 
     if _settings is None:
-        _settings = AISettings()
+        _settings = hydrate_ai_settings_from_platform(AISettings())
 
     return _settings
 

--- a/openfatture/ai/orchestration/__init__.py
+++ b/openfatture/ai/orchestration/__init__.py
@@ -42,6 +42,8 @@ Key Features:
 - **Observability**: Structured logging, metrics, audit trails
 """
 
+from openfatture import __version__
+
 # State Management
 # Human-in-the-Loop
 from openfatture.ai.orchestration.human_loop import (
@@ -164,7 +166,5 @@ __all__ = [
     "HumanReviewer",
     "ReviewDecisionLogger",
     "create_approval_checkpoint",
+    "__version__",
 ]
-
-# Version
-__version__ = "0.1.0"

--- a/openfatture/ai/runtime/constants.py
+++ b/openfatture/ai/runtime/constants.py
@@ -1,33 +1,34 @@
-"""Stable identifiers and shared constants for the assistant runtime."""
+"""Runtime constants — re-exports platform SSOT for assistant backends.
+
+Prefer importing from ``openfatture.platform.assistant_backends`` in core code.
+AI modules may keep using this path for convenience.
+"""
 
 from __future__ import annotations
 
-from typing import Final, Literal
+from typing import Final
 
-# Product backend ids (status/metrics; stable contract)
-BACKEND_CHAT: Final = "chat_agent_tool_loop"
-BACKEND_LANGGRAPH: Final = "langgraph_tool_loop"
-
-# Settings values map to backend ids (Literal keeps mypy/runtime aligned)
-AssistantBackendName = Literal["chat", "langgraph"]
-ASSISTANT_BACKEND_CHAT: Final[Literal["chat"]] = "chat"
-ASSISTANT_BACKEND_LANGGRAPH: Final[Literal["langgraph"]] = "langgraph"
+from openfatture.platform.assistant_backends import (
+    ASSISTANT_BACKEND_CHAT,
+    ASSISTANT_BACKEND_LANGGRAPH,
+    BACKEND_CHAT,
+    BACKEND_IDS,
+    BACKEND_LANGGRAPH,
+    DEFAULT_ASSISTANT_BACKEND,
+    AssistantBackendName,
+    resolve_backend_id,
+)
 
 DEFAULT_TOOL_MAX_ITERATIONS: Final[int] = 5
 
-BACKEND_IDS: Final[dict[str, str]] = {
-    ASSISTANT_BACKEND_CHAT: BACKEND_CHAT,
-    ASSISTANT_BACKEND_LANGGRAPH: BACKEND_LANGGRAPH,
-}
-
-
-def resolve_backend_id(assistant_backend: str) -> str:
-    """Map settings ``assistant_backend`` to the stable backend id string."""
-    key = (assistant_backend or ASSISTANT_BACKEND_CHAT).strip().lower()
-    if key == ASSISTANT_BACKEND_LANGGRAPH:
-        return BACKEND_LANGGRAPH
-    if key == ASSISTANT_BACKEND_CHAT:
-        return BACKEND_CHAT
-    raise ValueError(
-        f"Unknown assistant_backend={assistant_backend!r}; expected one of {sorted(BACKEND_IDS)}"
-    )
+__all__ = [
+    "ASSISTANT_BACKEND_CHAT",
+    "ASSISTANT_BACKEND_LANGGRAPH",
+    "AssistantBackendName",
+    "BACKEND_CHAT",
+    "BACKEND_IDS",
+    "BACKEND_LANGGRAPH",
+    "DEFAULT_ASSISTANT_BACKEND",
+    "DEFAULT_TOOL_MAX_ITERATIONS",
+    "resolve_backend_id",
+]

--- a/openfatture/ai/streaming/__init__.py
+++ b/openfatture/ai/streaming/__init__.py
@@ -33,6 +33,7 @@ Best Practices (2025):
 - Use factory methods (e.g., StreamEvent.content()) for clarity
 """
 
+from openfatture import __version__
 from openfatture.ai.streaming.accumulator import (
     MultiStreamAccumulator,
     StreamAccumulator,
@@ -46,6 +47,5 @@ __all__ = [
     # Accumulators
     "StreamAccumulator",
     "MultiStreamAccumulator",
+    "__version__",
 ]
-
-__version__ = "1.0.0"

--- a/openfatture/cli/commands/status.py
+++ b/openfatture/cli/commands/status.py
@@ -77,13 +77,20 @@ def _build_status() -> dict[str, Any]:
             p.name for p in hooks_dir.iterdir() if p.is_file() and not p.name.startswith(".")
         )
     readiness = _readiness(settings, extras)
-    # Keep mapping inline so core-only installs never import the AI package.
-    assistant_backend = str(getattr(settings, "assistant_backend", "chat") or "chat")
-    _backend_ids = {
-        "chat": "chat_agent_tool_loop",
-        "langgraph": "langgraph_tool_loop",
-    }
-    assistant_backend_id = _backend_ids.get(assistant_backend, "chat_agent_tool_loop")
+    # Backend ids SSOT: platform.assistant_backends (no AI package import).
+    from openfatture.platform.assistant_backends import (
+        DEFAULT_ASSISTANT_BACKEND,
+        resolve_backend_id,
+    )
+
+    assistant_backend = str(
+        getattr(settings, "assistant_backend", DEFAULT_ASSISTANT_BACKEND)
+        or DEFAULT_ASSISTANT_BACKEND
+    )
+    try:
+        assistant_backend_id = resolve_backend_id(assistant_backend)
+    except ValueError:
+        assistant_backend_id = resolve_backend_id(DEFAULT_ASSISTANT_BACKEND)
 
     return {
         "version": __version__,

--- a/openfatture/lightning/__init__.py
+++ b/openfatture/lightning/__init__.py
@@ -4,4 +4,6 @@ This module provides Lightning Network payment capabilities for Italian invoices
 including BOLT-11 invoice generation, payment monitoring, and liquidity management.
 """
 
-__version__ = "0.1.0"
+from openfatture import __version__
+
+__all__ = ["__version__"]

--- a/openfatture/platform/assistant_backends.py
+++ b/openfatture/platform/assistant_backends.py
@@ -1,0 +1,37 @@
+"""Single source of truth for assistant backend names and stable backend ids.
+
+Core CLI (status) and the AI runtime both import from here so mapping never
+drifts. Does not import the AI package.
+"""
+
+from __future__ import annotations
+
+from typing import Final, Literal
+
+AssistantBackendName = Literal["chat", "langgraph"]
+
+ASSISTANT_BACKEND_CHAT: Final[Literal["chat"]] = "chat"
+ASSISTANT_BACKEND_LANGGRAPH: Final[Literal["langgraph"]] = "langgraph"
+
+# Stable ids for status/metrics (do not rename lightly)
+BACKEND_CHAT: Final = "chat_agent_tool_loop"
+BACKEND_LANGGRAPH: Final = "langgraph_tool_loop"
+
+DEFAULT_ASSISTANT_BACKEND: Final[AssistantBackendName] = ASSISTANT_BACKEND_LANGGRAPH
+
+BACKEND_IDS: Final[dict[str, str]] = {
+    ASSISTANT_BACKEND_CHAT: BACKEND_CHAT,
+    ASSISTANT_BACKEND_LANGGRAPH: BACKEND_LANGGRAPH,
+}
+
+
+def resolve_backend_id(assistant_backend: str) -> str:
+    """Map settings ``assistant_backend`` to the stable backend id string."""
+    key = (assistant_backend or DEFAULT_ASSISTANT_BACKEND).strip().lower()
+    if key == ASSISTANT_BACKEND_LANGGRAPH:
+        return BACKEND_LANGGRAPH
+    if key == ASSISTANT_BACKEND_CHAT:
+        return BACKEND_CHAT
+    raise ValueError(
+        f"Unknown assistant_backend={assistant_backend!r}; expected one of {sorted(BACKEND_IDS)}"
+    )

--- a/openfatture/platform/config.py
+++ b/openfatture/platform/config.py
@@ -12,6 +12,8 @@ from pydantic_settings import (
     TomlConfigSettingsSource,
 )
 
+from openfatture.platform.assistant_backends import DEFAULT_ASSISTANT_BACKEND
+
 # Initialize platform directories
 dirs = PlatformDirs("openfatture", "venerelabs")
 
@@ -267,11 +269,12 @@ class Settings(BaseSettings):
 
     # AI Chat Assistant
     assistant_backend: Literal["chat", "langgraph"] = Field(
-        default="langgraph",
+        default=DEFAULT_ASSISTANT_BACKEND,
         description=(
             "Product assistant orchestration backend: "
             "'langgraph' (default StateGraph model↔tools loop) or "
-            "'chat' (ChatAgent rollback; tool loop still uses GraphAssistantBackend)."
+            "'chat' (ChatAgent rollback; tool loop still uses GraphAssistantBackend). "
+            "Default SSOT: openfatture.platform.assistant_backends.DEFAULT_ASSISTANT_BACKEND."
         ),
     )
     ai_chat_enabled: bool = Field(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -250,6 +250,9 @@ source = ["openfatture"]
 omit = ["*/tests/*", "*/__pycache__/*"]
 
 [tool.coverage.report]
+# Global package floor (SSOT). Payment module uses a higher floor in
+# payment-tests.yml (75%). CI may also pass --cov-fail-under explicitly.
+fail_under = 49
 exclude_lines = [
   "pragma: no cover",
   "def __repr__",

--- a/tests/platform/test_ssot.py
+++ b/tests/platform/test_ssot.py
@@ -1,0 +1,106 @@
+"""Single-source-of-truth contracts for version, backends, and AI credentials."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from openfatture import __version__ as pkg_version
+from openfatture.platform.assistant_backends import (
+    ASSISTANT_BACKEND_CHAT,
+    ASSISTANT_BACKEND_LANGGRAPH,
+    BACKEND_CHAT,
+    BACKEND_LANGGRAPH,
+    DEFAULT_ASSISTANT_BACKEND,
+    resolve_backend_id,
+)
+
+
+def test_package_version_is_ssot() -> None:
+    from openfatture.ai import __version__ as ai_version
+    from openfatture.ai.orchestration import __version__ as orch_version
+    from openfatture.ai.streaming import __version__ as stream_version
+    from openfatture.lightning import __version__ as ln_version
+    from openfatture.platform.config import Settings
+
+    assert ai_version == pkg_version
+    assert orch_version == pkg_version
+    assert stream_version == pkg_version
+    assert ln_version == pkg_version
+    assert Settings().app_version == pkg_version
+
+
+def test_assistant_backend_default_and_ids() -> None:
+    from openfatture.platform.config import Settings
+
+    assert DEFAULT_ASSISTANT_BACKEND == ASSISTANT_BACKEND_LANGGRAPH
+    assert Settings().assistant_backend == DEFAULT_ASSISTANT_BACKEND
+    assert resolve_backend_id("chat") == BACKEND_CHAT
+    assert resolve_backend_id("langgraph") == BACKEND_LANGGRAPH
+    assert resolve_backend_id(ASSISTANT_BACKEND_CHAT) == BACKEND_CHAT
+
+
+def test_status_backend_ids_match_ssot() -> None:
+    from openfatture.cli.commands.status import _build_status
+
+    data = _build_status()
+    assert data["assistant_backend"] == DEFAULT_ASSISTANT_BACKEND
+    assert data["assistant_backend_id"] == resolve_backend_id(DEFAULT_ASSISTANT_BACKEND)
+    assert data["version"] == pkg_version
+
+
+def test_ai_settings_hydrate_from_platform_ai_star(monkeypatch: pytest.MonkeyPatch) -> None:
+    """init/docs write AI_*; factory must see them via get_ai_settings()."""
+    from openfatture.ai.config.settings import (
+        AISettings,
+        hydrate_ai_settings_from_platform,
+        reset_ai_settings,
+    )
+    from openfatture.platform.config import Settings
+
+    # Clear advanced prefix so platform wins
+    for key in list(os.environ):
+        if key.upper().startswith("OPENFATTURE_AI_"):
+            monkeypatch.delenv(key, raising=False)
+
+    plat = Settings(
+        ai_provider="anthropic",
+        ai_model="claude-test",
+        ai_api_key="sk-ant-test",
+        ai_temperature=0.2,
+        ai_max_tokens=123,
+    )
+    with patch("openfatture.platform.config.get_settings", return_value=plat):
+        reset_ai_settings()
+        hydrated = hydrate_ai_settings_from_platform(AISettings())
+
+    assert hydrated.provider == "anthropic"
+    assert hydrated.anthropic_model == "claude-test"
+    assert hydrated.get_api_key_for_provider() == "sk-ant-test"
+    assert hydrated.temperature == 0.2
+    assert hydrated.max_tokens == 123
+
+
+def test_openfatture_ai_env_wins_over_platform(monkeypatch: pytest.MonkeyPatch) -> None:
+    from openfatture.ai.config.settings import AISettings, hydrate_ai_settings_from_platform
+    from openfatture.platform.config import Settings
+
+    monkeypatch.setenv("OPENFATTURE_AI_PROVIDER", "openai")
+    monkeypatch.setenv("OPENFATTURE_AI_OPENAI_API_KEY", "sk-openai-advanced")
+    monkeypatch.setenv("OPENFATTURE_AI_OPENAI_MODEL", "gpt-advanced")
+
+    plat = Settings(
+        ai_provider="anthropic",
+        ai_model="claude-test",
+        ai_api_key="sk-ant-test",
+    )
+    with patch("openfatture.platform.config.get_settings", return_value=plat):
+        # Load AISettings from env first, then hydrate (should not clobber)
+        ai = AISettings()
+        hydrated = hydrate_ai_settings_from_platform(ai)
+
+    assert hydrated.provider == "openai"
+    assert hydrated.openai_model == "gpt-advanced"
+    assert hydrated.get_api_key_for_provider() == "sk-openai-advanced"

--- a/tests/platform/test_ssot.py
+++ b/tests/platform/test_ssot.py
@@ -16,20 +16,30 @@ from openfatture.platform.assistant_backends import (
     DEFAULT_ASSISTANT_BACKEND,
     resolve_backend_id,
 )
+from openfatture.platform.extras import available_extras
 
 
-def test_package_version_is_ssot() -> None:
+def test_package_version_settings_ssot() -> None:
+    from openfatture.platform.config import Settings
+
+    assert Settings().app_version == pkg_version
+
+
+def test_lightning_version_reexports_package() -> None:
+    from openfatture.lightning import __version__ as ln_version
+
+    assert ln_version == pkg_version
+
+
+@pytest.mark.skipif(not available_extras().get("ai"), reason="ai extra not installed")
+def test_ai_subpackage_versions_reexport_package() -> None:
     from openfatture.ai import __version__ as ai_version
     from openfatture.ai.orchestration import __version__ as orch_version
     from openfatture.ai.streaming import __version__ as stream_version
-    from openfatture.lightning import __version__ as ln_version
-    from openfatture.platform.config import Settings
 
     assert ai_version == pkg_version
     assert orch_version == pkg_version
     assert stream_version == pkg_version
-    assert ln_version == pkg_version
-    assert Settings().app_version == pkg_version
 
 
 def test_assistant_backend_default_and_ids() -> None:
@@ -51,16 +61,13 @@ def test_status_backend_ids_match_ssot() -> None:
     assert data["version"] == pkg_version
 
 
+@pytest.mark.skipif(not available_extras().get("ai"), reason="ai extra not installed")
 def test_ai_settings_hydrate_from_platform_ai_star(monkeypatch: pytest.MonkeyPatch) -> None:
     """init/docs write AI_*; factory must see them via get_ai_settings()."""
-    from openfatture.ai.config.settings import (
-        AISettings,
-        hydrate_ai_settings_from_platform,
-        reset_ai_settings,
-    )
+    from openfatture.ai.config.settings import AISettings
+    from openfatture.ai.config.settings import hydrate_ai_settings_from_platform, reset_ai_settings
     from openfatture.platform.config import Settings
 
-    # Clear advanced prefix so platform wins
     for key in list(os.environ):
         if key.upper().startswith("OPENFATTURE_AI_"):
             monkeypatch.delenv(key, raising=False)
@@ -83,6 +90,7 @@ def test_ai_settings_hydrate_from_platform_ai_star(monkeypatch: pytest.MonkeyPat
     assert hydrated.max_tokens == 123
 
 
+@pytest.mark.skipif(not available_extras().get("ai"), reason="ai extra not installed")
 def test_openfatture_ai_env_wins_over_platform(monkeypatch: pytest.MonkeyPatch) -> None:
     from openfatture.ai.config.settings import AISettings, hydrate_ai_settings_from_platform
     from openfatture.platform.config import Settings
@@ -97,7 +105,6 @@ def test_openfatture_ai_env_wins_over_platform(monkeypatch: pytest.MonkeyPatch) 
         ai_api_key="sk-ant-test",
     )
     with patch("openfatture.platform.config.get_settings", return_value=plat):
-        # Load AISettings from env first, then hydrate (should not clobber)
         ai = AISettings()
         hydrated = hydrate_ai_settings_from_platform(ai)
 

--- a/tests/platform/test_ssot.py
+++ b/tests/platform/test_ssot.py
@@ -64,8 +64,11 @@ def test_status_backend_ids_match_ssot() -> None:
 @pytest.mark.skipif(not available_extras().get("ai"), reason="ai extra not installed")
 def test_ai_settings_hydrate_from_platform_ai_star(monkeypatch: pytest.MonkeyPatch) -> None:
     """init/docs write AI_*; factory must see them via get_ai_settings()."""
-    from openfatture.ai.config.settings import AISettings
-    from openfatture.ai.config.settings import hydrate_ai_settings_from_platform, reset_ai_settings
+    from openfatture.ai.config.settings import (
+        AISettings,
+        hydrate_ai_settings_from_platform,
+        reset_ai_settings,
+    )
     from openfatture.platform.config import Settings
 
     for key in list(os.environ):


### PR DESCRIPTION
## Summary

Implements Single Source of Truth best practices:

| Concern | SSOT | Consumers |
|---------|------|-----------|
| Package version | `openfatture.__version__` | `Settings.app_version`, `ai` / `lightning` / streaming / orchestration |
| Assistant backend ids | `platform.assistant_backends` | Settings default, status, AI runtime constants |
| Product AI credentials | Platform `AI_*` (init/docs) | `hydrate_ai_settings_from_platform` → provider factory |
| Advanced AI knobs | `OPENFATTURE_AI_*` | Wins when set |
| Coverage floor (global) | `pyproject` `fail_under = 49` | CI |

## Test plan

- [x] `tests/platform/test_ssot.py`
- [x] status / runtime / parity tests
- [ ] CI green