### PR TITLE
docs: inventory open technical debt after 2.1.0

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -41,12 +41,10 @@ fix the root cause instead.
 `ASSISTANT_BACKEND=chat` rollback; Lightning removed (see
 `docs/history/lightning/`); config SSOT for version/backends/AI credentials.
 
-**Optional next (on demand, not blocking):**
-- Split oversized modules when touched (`cash_flow_predictor`, large ops facades)
-- Product decision only: multi-agent workflows, TUI, MCP (stay non-CLI until then)
+**Optional next (on demand, not blocking):** see [TECHNICAL_DEBT.md](TECHNICAL_DEBT.md)
+for IDs and triggers (`D-SIZE`, `D-WF`, product decisions). No release-blocking debt.
 
 See [TECHNICAL_DEBT.md](TECHNICAL_DEBT.md) and [releases/v2.1.0.md](releases/v2.1.0.md).
-
 ## Coverage floors (CI)
 
 | Suite | Floor | Source of truth |

--- a/docs/TECHNICAL_DEBT.md
+++ b/docs/TECHNICAL_DEBT.md
@@ -1,135 +1,223 @@
 # Technical Debt Inventory
 
-Honest inventory of remaining debt **after** modernization **2.0** and the
-**2.1.0** LangGraph default flip.
+Honest inventory of **open** and **closed** debt after modernization **2.0**,
+the **2.1.0** LangGraph default flip, and post-2.1 hygiene (#31–#34).
 
 **Last updated:** 2026-08-08  
+**Version baseline:** 2.1.0 (`v2.1.0`)
+
 Related: [STATUS.md](STATUS.md), [CORE_VS_EXTENSIONS.md](CORE_VS_EXTENSIONS.md),
-[ARCHITECTURE_REDESIGN.md](ARCHITECTURE_REDESIGN.md),
-[releases/v2.1.0.md](releases/v2.1.0.md), [releases/v2.0.0.md](releases/v2.0.0.md).
+[ARCHITECTURE.md](ARCHITECTURE.md), [releases/v2.1.0.md](releases/v2.1.0.md).
 
 ---
 
 ## Verdict
 
-Structural modernization and AI product backend flip are **done**. Remaining
-debt is **oversized modules** and **experimental multi-agent workflows**, not
-packaging chaos. Experimental Lightning Network support was **removed** (see
-`docs/history/lightning/`).
+| Signal | State |
+|--------|--------|
+| Structural modernization (2.0) | **Done** |
+| AI product backend (LangGraph default) | **Done** (2.1.0) |
+| Packaging / CLI surface / suppressions | **Clean** |
+| Real remaining debt | **Oversized modules** + **experimental workflows** (not on CLI) |
+| Blocking release debt | **None** |
 
-| Area | Debt level | Notes |
-|------|------------|--------|
-| Public CLI surface | Low | Small agentic surface; status/extras clean |
-| Core billing / SDI / payment | Low | Tools → application; billing re-exports use-cases |
-| Package layout | Low | Bounded packages; no empty placeholders |
-| AI runtime | Low | Default `langgraph_tool_loop`; single tool-loop; ChatAgent slimmed (structured + rollback) |
-| Lightning | **Removed** | Incomplete LND gRPC; archived docs under `docs/history/lightning/` |
-| RAG auto-update | Low | Callback required; default auto-update off |
-| Tooling / types | Low | No in-code suppressions; only E501 formatter ignore |
-| Tests | Low | Skips mostly for external services / interactive |
+Remaining work is **maintenance when touched** or **product decisions**, not
+firefighting. Do not invent new public domain CLI commands to “finish” debt.
 
 ---
 
-## Modernization status
+## Debt level by area
 
-| Phase | Status |
-|-------|--------|
-| Repo hygiene + docs | done |
-| Ruff-only tooling | done |
-| Optional extras | done |
-| D0–D3 (layout, tools, runtime) | done |
-| Honesty gates (Lightning mock, RAG queue) | done |
-| 2.0.0–2.0.2 releases | done |
-| LangGraph opt-in product backend | done (2.0.x) |
-| LangGraph **default** + ChatAgent slim | done (**2.1.0**) |
-
----
-
-## High priority (real product risk)
-
-### 1. AI product path — resolved for 2.1.0
-
-- **Default:** `AssistantRuntime` → `GraphAssistantBackend` (`langgraph_tool_loop`).
-- **Rollback:** `ASSISTANT_BACKEND=chat` → slim `ChatAgent` (structured output +
-  same graph for tool/plain/ReAct turns).
-- **Workflows:** `ai.orchestration.workflows.*` remain internal/experimental;
-  not on the public CLI.
-
-### 2. AI tools → application services — done
-
-- Thin adapters under `openfatture/ai/tools`.
-- Follow-up: split large `*_ops.py` / command modules where complexity grows.
-
-### 3. RAG auto-update queue honesty — resolved
-
-- Requires a real `reindex_callback`; default auto-update remains disabled.
-
-### 4. Lightning Network — removed
-
-- Incomplete experimental module removed from the product tree.
-- Historical docs: `docs/history/lightning/`.
+| Area | Level | Notes |
+|------|-------|--------|
+| Public CLI surface | Low | Agentic surface only: `init`, `assistant`, `interactive`, `config`, `status` |
+| Core billing / SDI / payment | Low | Tools → application services; payment suite floor 75% |
+| Package layout | Low | Bounded packages; no empty placeholders; extras explicit |
+| Config / SSOT | Low | Version, backends, AI credentials hydrated consistently (#32) |
+| AI runtime (product path) | Low | Default `langgraph_tool_loop`; single tool-loop; ChatAgent slim rollback |
+| Multi-agent workflows | Medium | Present under `ai.orchestration.workflows.*`; **not** on public CLI |
+| Module size / cohesion | Medium | A few files >700 LOC; split only when editing them |
+| Lightning | **Removed** | Incomplete LND gRPC; archive under `docs/history/lightning/` |
+| RAG auto-update | Low | Real `reindex_callback` required; default auto-update off |
+| Tooling / types | Low | Zero in-code `noqa` / `type: ignore` / `pragma: no cover` |
+| Tests | Low | Skips are for extras, external services, or intentional env limits |
+| Coverage floors | Acceptable | Package 49%; payment 75% (measured ~78%) |
 
 ---
 
-## Medium priority
+## Closed (do not re-open)
 
-### Oversized modules
+Keep this ledger so old debt is not rediscovered as open.
 
-| Module | ~LOC | Note |
-|--------|------|------|
-| `ai/agents/cash_flow_predictor.py` | ~1091 | P1 split candidate |
-| `ai/orchestration/workflows/invoice_creation.py` | ~921 | experimental |
-| `ai/providers/openai.py` | ~855 | provider adapter |
-| `ai/tools/registry/core.py` | ~718 | package already split |
-| `billing/application/invoice_commands.py` | ~714 | P2 |
-| `storage/database/models.py` | ~672 | split by bounded context |
-| `billing/application/preventivo_ops.py` | ~550 | P2 |
-
-`chat_agent.py` is slimmed (structured + graph delegation). Registry is a package.
-
-### Experimental workflow human interrupt
-
-- Confidence auto-gates or honest `awaiting_approval`; no invented human decisions.
-- Real CLI interrupt is not on the product path.
-
-### Type-safety / lint
-
-- **Resolved:** zero in-code `noqa` / `type: ignore` / `pragma: no cover`.
-- Ruff global ignore is only `E501` (formatter-owned).
-- `mypy` still ignores entire `tests.*` (optional incremental typing later).
-- Third-party packages without stubs use `ignore_missing_imports` in
-  `pyproject.toml` (external, not project debt).
-
-### Bulkhead / registry TODOs
-
-- Queue length tracking for bulkhead not implemented (observability).
-
-### ML accuracy drift
-
-- Signal explicitly unavailable (`status: not_implemented`); no silent success claim.
-
-### `async_bridge` nested loops
-
-- `nest_asyncio` optional, else worker thread; primary path `asyncio.run`.
+| Item | Resolved in | Notes |
+|------|-------------|--------|
+| Repo hygiene + living docs | 2.0 | Canonical docs; history under `docs/history/` |
+| Ruff-only tooling | 2.0 | No flake8/black/isort dual stack |
+| Optional dependency extras | 2.0 | `ai` / `rag` / `ml` / `all` |
+| D0 non-core cut | 2.0 | Voice, scraper, orphan agents out of product path |
+| D1 package reorg | 2.0 | `billing` / `events` / `hooks` / `platform` / `pdf` |
+| Experimental `plugins` package | 2.0 | Removed; hooks + future MCP contracts |
+| AI tools → application adapters | 2.0 | Thin tools over use-cases |
+| Unified `ai.runtime` entry | 2.0 | Assistant entry is runtime-owned |
+| RAG queue honesty | 2.0 | No silent no-op reindex |
+| LangGraph product opt-in | 2.0.x (#29) | Backend available behind config |
+| LangGraph **default** + ChatAgent slim | **2.1.0** (#30) | One tool-loop; chat is rollback |
+| Dependabot / Ruff 0.16 readiness | #28 | CI dependency batch |
+| Project config hygiene | #31 | Post-2.1 config cleanup |
+| SSOT: version, backends, AI credentials | #32 | Single sources; hydrate rules tested |
+| Lightning Network module | #33 | Removed from tree; docs archived |
+| Dead Lightning i18n keys | #34 | GC’d from all `cli.ftl` locales |
+| Redundant payment-only lint job | #34 | Package-wide `lint` in `test.yml` covers it |
 
 ---
 
-## Low priority / acceptable
+## Open debt
+
+Each item has an **ID**, **impact**, **trigger** (when to act), and **non-goal**
+if relevant. Prefer fixing debt in the same PR that touches the module.
+
+### D-SIZE — Oversized modules
+
+**Impact:** Harder review, higher merge conflict risk, mixed concerns.  
+**Risk to users:** Low until bugs land in these files.  
+**Trigger:** Split **when you edit** them for a real feature/bug; do not drive
+standalone “LOC reduction” PRs.
+
+| Module | ~LOC | Suggested split direction | Priority |
+|--------|------|---------------------------|----------|
+| `ai/agents/cash_flow_predictor.py` | ~1091 | Predictor vs features vs report/IO | P1 |
+| `ai/orchestration/workflows/invoice_creation.py` | ~921 | Nodes / gates / IO (only if productized) | P2* |
+| `ai/providers/openai.py` | ~855 | Client vs streaming vs tool-call mapping | P2 |
+| `ai/tools/registry/core.py` | ~718 | Already a package; further extract bulkhead/metrics if grows | P3 |
+| `billing/application/invoice_commands.py` | ~714 | Commands vs validation vs side-effects | P2 |
+| `storage/database/models.py` | ~672 | Models by bounded context (billing / payment / events) | P2 |
+| `ai/orchestration/react.py` | ~633 | Keep unless ReAct path expands | P3 |
+| `ai/domain/agent.py` | ~623 | Base agent vs helpers | P3 |
+| `ai/orchestration/workflows/cash_flow_analysis.py` | ~615 | Experimental workflow | P2* |
+| `ai/orchestration/workflows/compliance_check.py` | ~592 | Experimental workflow | P2* |
+| `payment/application/services/reconciliation_service.py` | ~579 | Matching strategies vs orchestration | P3 |
+| `ai/ml/features.py` | ~565 | Feature groups by domain | P3 |
+| `billing/application/preventivo_ops.py` | ~550 | Ops vs PDF/email side paths | P2 |
+| `payment/application/payment_commands.py` | ~541 | Commands vs importers glue | P3 |
+
+\*P2 only if workflows move toward product; otherwise leave experimental.
+
+**Done nearby:** `chat_agent.py` slimmed (structured + graph delegation);
+`ai.tools.registry` is already a package.
+
+### D-WF — Experimental multi-agent workflows
+
+**Location:** `openfatture/ai/orchestration/workflows/`  
+(`invoice_creation`, `compliance_check`, `cash_flow_analysis`)
+
+| Aspect | Status |
+|--------|--------|
+| Public CLI exposure | **No** — intentional |
+| Config flag | `enable multi-agent orchestration (experimental)` in AI settings |
+| Human interrupt | Confidence auto-gates or honest `awaiting_approval`; **no** invented human decisions |
+| Product path | Tool-loop via `GraphAssistantBackend` only |
+
+**Impact:** Code weight and maintenance cost if left half-productized.  
+**Trigger:** Explicit product decision to ship multi-agent UX (still assistant-first).  
+**Non-goal:** Do not add Typer subcommands for each workflow.
+
+### D-ML-DRIFT — Accuracy-drift signal not implemented
+
+**Location:** `ai/ml/retraining/triggers.py` (`_check_accuracy_drift`)  
+**Behavior:** Logs `status: not_implemented`; does **not** claim success.  
+**Impact:** Retraining will not fire on accuracy drift until implemented.  
+**Trigger:** When production ML monitoring is required.  
+**Honesty rule:** Keep the explicit unavailable signal; never fake a metric.
+
+### D-OBS — Bulkhead queue length is approximate
+
+**Location:** `ai/tools/registry/core.py` (+ `ToolResult.bulkhead_queue_length`)  
+**Behavior:** Derived from semaphore `_value` / max concurrent, not a real wait-queue depth.  
+**Impact:** Observability only; concurrency limiting still works.  
+**Trigger:** If tool-resilience dashboards need accurate queue depth.
+
+### D-PDF-PAGOPA — pagoPA QR not implemented
+
+**Location:** `pdf/generator.py` (`pagopa_qr_not_implemented` warning)  
+**Impact:** PDF generation continues without QR when that path is requested.  
+**Trigger:** Customer need for pagoPA QR on generated PDFs.
+
+### D-TYPES-TESTS — mypy does not type-check `tests.*`
+
+**Location:** `pyproject.toml` mypy config  
+**Impact:** Test-only type bugs slip until runtime.  
+**Trigger:** Optional incremental enable for critical test packages.  
+**Not debt:** third-party `ignore_missing_imports` for packages without stubs.
+
+### D-COV — Global coverage floor is a baseline, not a goal
+
+| Suite | Floor | Source |
+|-------|-------|--------|
+| Full package | 49% | `[tool.coverage.report] fail_under` + `test.yml` |
+| Payment | 75% | `payment-tests.yml` (~78% measured) |
+
+**Impact:** Prevents large regressions; does not drive quality by itself.  
+**Trigger:** Raise floors only when a suite sustainably exceeds them.  
+**Local default:** pytest without coverage (speed); use CI flags for reports.
+
+### D-ASYNC — Nested event-loop bridge
+
+**Location:** platform async bridge (`nest_asyncio` optional, else worker thread;
+primary path `asyncio.run`).  
+**Impact:** Edge cases in nested loops / notebook-like hosts.  
+**Trigger:** Only if interactive/assistant hosts hit real nested-loop failures.
+
+---
+
+## Product decisions (not code debt yet)
+
+These need a **product decision and release plan** before implementation.
+Documenting them here prevents them from being treated as silent backlog bugs.
+
+| Decision | Default stance | Notes |
+|----------|----------------|--------|
+| Multi-agent workflows on product path | Off / experimental | See D-WF |
+| Textual (or other) TUI | Non-goal | Interactive terminal exists; full TUI is separate |
+| MCP server / external tool bus | Non-goal until designed | Extensions via hooks + tool contracts today |
+| Browser / web app surface | Explicit non-goal | See STATUS |
+| Domain CLI command tree growth | Forbidden | Domain ops stay on assistant + application layer |
+| Lightning / LND payments | Removed | Archive only; reintroduce only as greenfield design |
+
+---
+
+## Acceptable / intentional (not debt)
 
 | Item | Why acceptable |
 |------|----------------|
-| `except Exception` in hooks/events/email | Intentional isolation |
-| External-service test skips | Correct for CI |
-| Ruff `E501` ignore | Line length owned by `ruff format` |
-| `tests/**` E402 per-file | Fixture/path setup before SUT import |
-| `__init__.py` F401 per-file | Public re-export barrels |
-| Global coverage floor ~49% in CI | Baseline; payment suite has higher floor (75%) |
+| `except Exception` in hooks / events / email | Isolation of untrusted or peripheral code |
+| Test skips for missing extras / external services | Correct for CI and optional installs |
+| Ruff global ignore `E501` | Line length owned by `ruff format` |
+| `tests/**` E402 per-file ignore | Path setup before SUT import |
+| `__init__.py` F401 per-file ignore | Public re-export barrels |
+| Interactive / TTY-only test skips | Cannot assert full UX headlessly |
+| SQLite in-memory concurrency skips | Known engine limit, not app bug |
 
 ---
 
 ## Recommended burn-down order
 
-1. Split oversized modules (`cash_flow_predictor`, invoice commands, models)
-2. Honest experimental workflow approval nodes (if ever productized)
-3. Optional: mypy on selected tests; import-linter boundaries
-4. Optional: Textual TUI (product decision)
+Act only with a real trigger. Order is **cost/benefit**, not a sprint backlog.
+
+1. **D-SIZE P1** — split `cash_flow_predictor` when forecasting is next touched  
+2. **D-SIZE P2** — `invoice_commands` / `models.py` / `preventivo_ops` when billing storage changes  
+3. **D-WF** — productize or delete experimental workflows after an explicit decision  
+4. **D-ML-DRIFT** — only with real monitoring requirements  
+5. **D-OBS / D-PDF-PAGOPA / D-TYPES-TESTS** — opportunistic  
+6. **Product decisions** (TUI / MCP / web) — separate design + release, not drive-by PRs  
+
+---
+
+## How to keep this document honest
+
+- Update **Last updated** and the closed ledger when debt is removed or accepted.  
+- Prefer **IDs** (`D-SIZE`, `D-WF`, …) in PR descriptions when intentionally
+  burning debt.  
+- Do not list “nice to have” refactors without a trigger.  
+- Historical investigation reports live under `docs/history/` and
+  `docs/reports/` — they are **not** current claims.  
+- In-code suppressions remain **forbidden**; fix the root cause instead.


### PR DESCRIPTION
## Summary

- Rewrite `docs/TECHNICAL_DEBT.md` as the post-2.1.0 debt inventory:
  - **Closed ledger** for modernization + #28–#34 so old items are not rediscovered
  - **Open debt IDs** with impact, trigger, and non-goals (`D-SIZE`, `D-WF`, `D-ML-DRIFT`, `D-OBS`, `D-PDF-PAGOPA`, `D-TYPES-TESTS`, `D-COV`, `D-ASYNC`)
  - **Product decisions** (TUI/MCP/workflows/web) separated from code debt
  - Trigger-based burn-down order (no fake sprint backlog)
- `docs/STATUS.md` points optional next work at the inventory; no release-blocking debt

## Test plan

- [x] Docs-only change
- [ ] Spot-check LOC table vs tree when reviewing
- [ ] CI green (docs/link gates if any)